### PR TITLE
Use math to calculate version byte size.

### DIFF
--- a/src/opensearch_sdk_py/transport/stream_output.py
+++ b/src/opensearch_sdk_py/transport/stream_output.py
@@ -35,6 +35,23 @@ class StreamOutput(BytesIO):
                 break
         return self.write(result)
 
+    @classmethod
+    def v_int_size(self, i: int) -> int:
+        if i < 0x80:
+            return 1
+        result = 0
+        while True:
+            result += 1
+            i >>= 7
+            if (i & ~0x7F) == 0:
+                result += 1
+                break
+        return result
+
+    @classmethod
+    def version_size(self, version: Version) -> int:
+        return self.v_int_size(version.id)
+
     def write_version(self, version: Version) -> int:
         return self.write_v_int(version.id)
 

--- a/src/opensearch_sdk_py/transport/transport_handshaker_handshake_request.py
+++ b/src/opensearch_sdk_py/transport/transport_handshaker_handshake_request.py
@@ -28,13 +28,10 @@ class TransportHandshakerHandshakeRequest(TransportRequest):
 
     def write_to(self, output: StreamOutput) -> "TransportHandshakerHandshakeRequest":
         super().write_to(output)
-        version_bytes = StreamOutput()
+        StreamOutput()
         if self.version:
-            # TODO: can we know the future size of version without writing it to a stream?
-            version_bytes = StreamOutput()
-            version_bytes.write_version(self.version)
-            output.write_v_int(len(version_bytes.getvalue()))
-            output.write(version_bytes.getvalue())
+            output.write_v_int(StreamOutput.version_size(self.version))
+            output.write_version(self.version)
         return self
 
     def __str__(self) -> str:

--- a/tests/transport/test_stream_output.py
+++ b/tests/transport/test_stream_output.py
@@ -67,6 +67,26 @@ class TestStreamOutput(unittest.TestCase):
         out.write_version(v)
         self.assertEqual(out.getvalue(), b"\x83\x97\x80\x41")
 
+    def test_version_size(self) -> None:
+        out = StreamOutput()
+        v = Version(2100099)
+        out.write_version(v)
+        self.assertEqual(StreamOutput.version_size(v), len(out.getvalue()))
+
+    def test_write_version_zero(self) -> None:
+        out = StreamOutput()
+        v = Version()
+        v.id = 0
+        out.write_version(v)
+        self.assertEqual(out.getvalue(), b"\x00")
+
+    def test_version_zero_size(self) -> None:
+        out = StreamOutput()
+        v = Version()
+        v.id = 0
+        out.write_version(v)
+        self.assertEqual(StreamOutput.version_size(v), len(out.getvalue()))
+
     def test_write_long(self) -> None:
         out = StreamOutput()
         out.write_long(5409454583320448)


### PR DESCRIPTION
### Description

Avoids creating a stream first to write version size.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
