### PR TITLE
Enable Renovate

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -26,6 +26,12 @@
     "issueType": "DEPENDENCY"
   },
   "remediateSettings": {
+    "enableRenovate": true,
+    "extends": [
+      "config:base",
+      ":gitSignOff",
+      "github>whitesource/merge-confidence:beta"
+    ],
     "workflowRules": {
       "enabled": true
     }


### PR DESCRIPTION
### Description

Actually flips the "on" switch for Renovate.  Adds a few configs to enable beta features and git-signoff dependency updates.  Expect a "Dependency Dashboard" issue to be created after you merge to give you the warm fuzzy that it's actually working.

### Issues Resolved

I should have checked more carefully in my comments on #4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
