### PR TITLE
The default coverage file name is .coverage.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,9 @@ jobs:
           poetry install
           protoc -I=$SRC_DIR --python_out=$SRC_DIR $SRC_DIR/*.proto
           2to3 --no-diff -n -w $SRC_DIR
-          poetry run coverage run --source=src -m pytest -v --cov-report=xml
+          poetry run coverage run --source=src -m pytest -v
+          poetry run coverage xml
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml


### PR DESCRIPTION
### Description

It was working on my fork, but not on main. Strange.

This works now, even showing files in https://app.codecov.io/github/opensearch-project/opensearch-sdk-py/commit/8d650c25b67a8e5602f16fe6c92813f79c51e36d/tree.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
