### PR TITLE
Implement extension points for handling Rest Requests

### DIFF
--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -13,8 +13,11 @@ import logging
 import socket
 from typing import Any
 
+from hello_extension import HelloExtension
+
 from opensearch_sdk_py.actions.internal.discovery_extensions_request_handler import DiscoveryExtensionsRequestHandler
 from opensearch_sdk_py.actions.request_handlers import RequestHandlers
+from opensearch_sdk_py.rest.extension_rest_handlers import ExtensionRestHandlers
 from opensearch_sdk_py.transport.acknowledged_response import AcknowledgedResponse
 from opensearch_sdk_py.transport.initialize_extension_response import InitializeExtensionResponse
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
@@ -88,4 +91,23 @@ async def run_server() -> None:
 
 
 logging.basicConfig(encoding="utf-8", level=logging.INFO)
+
+# TODO We should pass this instance to the SDK and SDK should execute the code below
+extension = HelloExtension()
+
+# TODO Move this code to SDK "runner" class
+# Map interface name to instance
+interfaces = dict()
+for interface in extension.get_implemented_interfaces():
+    interfaces[interface[0]] = interface[1]
+    logging.info(f"Registering {interface[0]} to point to {interface[1]}")
+# If it's an ActionExtension it has this extension point
+# TODO This could perhaps be better with isinstance()
+if "ActionExtension" in interfaces.keys():
+    for handler in getattr(interfaces["ActionExtension"], "get_extension_rest_handlers")():
+        ExtensionRestHandlers().register(handler)
+        logging.info(f"Registering {handler}")
+
+# Back to your regularly scheduled asyncio.
+# TODO: move this loop to SDK
 asyncio.run(run_server())

--- a/samples/hello/hello_extension.py
+++ b/samples/hello/hello_extension.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+from hello_rest_handler import HelloRestHandler
+
+from opensearch_sdk_py.api.action_extension import ActionExtension
+from opensearch_sdk_py.api.extension import Extension
+from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
+
+
+class HelloExtension(Extension, ActionExtension):
+    def get_implemented_interfaces(self) -> list[tuple]:
+        # TODO: This is lazy and temporary.
+        # Really we should be using this class to call some SDK class run(),
+        # passing an instance of ourself to the SDK and letting it parse out
+        # the superclass names with class.__mro__ and calling the appropriate
+        # implemented functions from the interfaces.
+        return [("Extension", self), ("ActionExtension", self)]
+
+    def get_extension_rest_handlers(self) -> list[ExtensionRestHandler]:
+        return [HelloRestHandler()]

--- a/samples/hello/hello_rest_handler.py
+++ b/samples/hello/hello_rest_handler.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import logging
+
+from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
+from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
+from opensearch_sdk_py.rest.named_route import NamedRoute
+from opensearch_sdk_py.rest.rest_method import RestMethod
+from opensearch_sdk_py.rest.rest_status import RestStatus
+
+
+class HelloRestHandler(ExtensionRestHandler):
+    def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
+        logging.debug(f"handling {rest_request}")
+
+        response_bytes = bytes("Hello from Python!", "utf-8") + b"\x20\xf0\x9f\x91\x8b"
+        return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.TEXT_CONTENT_TYPE)
+
+    def routes(self) -> list[NamedRoute]:
+        return [NamedRoute(method=RestMethod.GET, path="/hello", unique_name="greeting")]

--- a/src/opensearch_sdk_py/actions/internal/discovery_extensions_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/discovery_extensions_request_handler.py
@@ -10,6 +10,7 @@
 import logging
 
 from opensearch_sdk_py.actions.request_handler import RequestHandler
+from opensearch_sdk_py.rest.extension_rest_handlers import ExtensionRestHandlers
 from opensearch_sdk_py.transport.initialize_extension_request import InitializeExtensionRequest
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
 from opensearch_sdk_py.transport.register_rest_actions_request import RegisterRestActionsRequest
@@ -39,7 +40,7 @@ class DiscoveryExtensionsRequestHandler(RequestHandler):
             OutboundMessageRequest(
                 thread_context=request.thread_context_struct,
                 features=request.features,
-                message=RegisterRestActionsRequest("hello-world", ["GET /hello hw_greeting"]),
+                message=RegisterRestActionsRequest("hello-world", ExtensionRestHandlers().named_routes()),
                 version=request.version,
                 action="internal:discovery/registerrestactions",
                 is_handshake=False,

--- a/src/opensearch_sdk_py/actions/internal/extensions_restexecuteonextensiontaction_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/extensions_restexecuteonextensiontaction_handler.py
@@ -10,9 +10,9 @@
 import logging
 
 from opensearch_sdk_py.actions.request_handler import RequestHandler
+from opensearch_sdk_py.rest.extension_rest_handlers import ExtensionRestHandlers
 from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
 from opensearch_sdk_py.rest.rest_execute_on_extension_response import RestExecuteOnExtensionResponse
-from opensearch_sdk_py.rest.rest_status import RestStatus
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
 from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.stream_input import StreamInput
@@ -27,14 +27,21 @@ class ExtensionRestRequestHandler(RequestHandler):
         extension_rest_request = ExtensionRestRequest().read_from(input)
         logging.debug(f"< {extension_rest_request}")
 
-        response_bytes = bytes("Hello from Python!", "utf-8")
-        response_bytes += b"\x20\xf0\x9f\x91\x8b"
+        route = f"{extension_rest_request.method.name} {extension_rest_request.path}"
+        response = ExtensionRestHandlers().handle(route, extension_rest_request)
 
         return self.send(
             OutboundMessageResponse(
                 request.thread_context_struct,
                 request.features,
-                RestExecuteOnExtensionResponse(RestStatus.OK, "text/html; charset=utf-8", response_bytes),
+                RestExecuteOnExtensionResponse(
+                    status=response.status,
+                    content_type=response.content_type,
+                    content=response.content,
+                    headers=response.headers,
+                    consumed_params=response.consumed_params,
+                    content_consumed=response.content_consumed,
+                ),
                 request.version,
                 request.request_id,
                 request.is_handshake,

--- a/src/opensearch_sdk_py/api/action_extension.py
+++ b/src/opensearch_sdk_py/api/action_extension.py
@@ -1,0 +1,22 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+# https://github.com/opensearch-project/opensearch-sdk-java/blob/main/src/main/java/org/opensearch/sdk/api/ActionExtension.java
+
+from abc import ABC, abstractmethod
+
+from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
+
+
+class ActionExtension(ABC):
+    @abstractmethod
+    def get_extension_rest_handlers(self) -> list[ExtensionRestHandler]:
+        """
+        Implementer should return a list of classes implementing ExtensionRestHandler
+        """

--- a/src/opensearch_sdk_py/api/extension.py
+++ b/src/opensearch_sdk_py/api/extension.py
@@ -1,0 +1,21 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+# https://github.com/opensearch-project/opensearch-sdk-java/blob/main/src/main/java/org/opensearch/sdk/Extension.java
+
+from abc import ABC, abstractmethod
+
+
+class Extension(ABC):
+    @abstractmethod
+    def get_implemented_interfaces(self) -> list[tuple]:
+        """
+        Implementer should return a list of tuples containing the implemented interface (such as
+        Extension, ActionExtension, etc.) and the implementing class.
+        """

--- a/src/opensearch_sdk_py/rest/extension_rest_handler.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handler.py
@@ -1,0 +1,25 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+# https://github.com/opensearch-project/opensearch-sdk-java/blob/main/src/main/java/org/opensearch/sdk/rest/ExtensionRestHandler.java
+
+from abc import ABC, abstractmethod
+
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
+from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
+from opensearch_sdk_py.rest.named_route import NamedRoute
+
+
+class ExtensionRestHandler(ABC):
+    @abstractmethod
+    def handle_request(rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
+        pass
+
+    def routes() -> list[NamedRoute]:
+        return []

--- a/src/opensearch_sdk_py/rest/extension_rest_handler.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handler.py
@@ -21,5 +21,5 @@ class ExtensionRestHandler(ABC):
     def handle_request(rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
         pass
 
-    def routes() -> list[NamedRoute]:
+    def routes(self) -> list[NamedRoute]:
         return []

--- a/src/opensearch_sdk_py/rest/extension_rest_handlers.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handlers.py
@@ -1,0 +1,39 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+from typing import Dict
+
+from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
+from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
+
+
+class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
+    _singleton = None
+    _named_routes: list[str] = []
+
+    def __new__(cls):  # type:ignore
+        if cls._singleton is None:
+            cls._singleton = super(ExtensionRestHandlers, cls).__new__(cls)
+        return cls._singleton
+
+    def register(self, klass: ExtensionRestHandler) -> None:
+        for route in getattr(klass, "routes")():
+            # for matching the handler on the extension side only method and path matter
+            self[route.key] = klass
+            # but we have to send the full named route to OpenSearch
+            self._named_routes.append(str(route))
+
+    def named_routes(self) -> list[str]:
+        return self._named_routes
+
+    def handle(self, route: str, request: ExtensionRestRequest) -> ExtensionRestResponse:
+        handler = self[route]
+        # TODO error response if no handler found (handler is None)
+        return getattr(handler, "handle_request")(request)

--- a/src/opensearch_sdk_py/rest/extension_rest_response.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_response.py
@@ -1,0 +1,55 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+# https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestResponse.java
+
+from opensearch_sdk_py.rest.rest_status import RestStatus
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.transport_response import TransportResponse
+
+
+class ExtensionRestResponse(TransportResponse):
+    TEXT_CONTENT_TYPE = "text/plain; charset=UTF-8"
+    JSON_CONTENT_TYPE = "application/json; charset=UTF-8"
+    OCTET_CONTENT_TYPE = "application/octet-stream"
+
+    def __init__(
+        self,
+        status: RestStatus = None,
+        content: bytes = b"",
+        content_type: str = TEXT_CONTENT_TYPE,
+        consumed_params: list[str] = [],
+        content_consumed: bool = False,
+    ) -> None:
+        super().__init__()
+        self.status = status
+        self.content = content
+        self.content_type = content_type
+        self.consumed_params = consumed_params
+        self.content_consumed = content_consumed
+
+    def read_from(self, input: StreamInput) -> "ExtensionRestResponse":
+        super().read_from(input)
+        self.status = input.read_enum(RestStatus)
+        self.content = input.read_bytes(input.read_array_size())
+        self.content_type = input.read_string()
+        self.consumed_params = input.read_string_array()
+        self.content_consumed = input.read_boolean()
+        return self
+
+    def write_to(self, output: StreamOutput) -> "ExtensionRestResponse":
+        super().write_to(output)
+        output.write_enum(self.status)
+        output.write_v_int(len(self.content))
+        output.write(self.content)
+        output.write_string(self.content_type)
+        output.write_string_array(self.consumed_params)
+        output.write_boolean(self.content_consumed)
+        return self

--- a/src/opensearch_sdk_py/rest/extension_rest_response.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_response.py
@@ -25,6 +25,7 @@ class ExtensionRestResponse(TransportResponse):
         status: RestStatus = None,
         content: bytes = b"",
         content_type: str = TEXT_CONTENT_TYPE,
+        headers: dict[str, list[str]] = dict(),
         consumed_params: list[str] = [],
         content_consumed: bool = False,
     ) -> None:
@@ -32,6 +33,7 @@ class ExtensionRestResponse(TransportResponse):
         self.status = status
         self.content = content
         self.content_type = content_type
+        self.headers = headers
         self.consumed_params = consumed_params
         self.content_consumed = content_consumed
 
@@ -40,6 +42,7 @@ class ExtensionRestResponse(TransportResponse):
         self.status = input.read_enum(RestStatus)
         self.content = input.read_bytes(input.read_array_size())
         self.content_type = input.read_string()
+        self.headers = input.read_string_to_string_array_dict()
         self.consumed_params = input.read_string_array()
         self.content_consumed = input.read_boolean()
         return self
@@ -50,6 +53,7 @@ class ExtensionRestResponse(TransportResponse):
         output.write_v_int(len(self.content))
         output.write(self.content)
         output.write_string(self.content_type)
+        output.write_string_to_string_array_dict(self.headers)
         output.write_string_array(self.consumed_params)
         output.write_boolean(self.content_consumed)
         return self

--- a/src/opensearch_sdk_py/rest/named_route.py
+++ b/src/opensearch_sdk_py/rest/named_route.py
@@ -1,0 +1,28 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+# https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/rest/NamedRoute.java
+
+from opensearch_sdk_py.rest.rest_method import RestMethod
+
+
+class NamedRoute:
+    def __init__(
+        self,
+        method: RestMethod = None,
+        path: str = "",
+        unique_name: str = "",
+    ):
+        super().__init__()
+        self.method = method
+        self.path = path
+        self.unique_name = unique_name
+
+    def __str__(self) -> str:
+        return f"{self.method.name} {self.path} {self.unique_name}"

--- a/src/opensearch_sdk_py/rest/named_route.py
+++ b/src/opensearch_sdk_py/rest/named_route.py
@@ -15,14 +15,16 @@ from opensearch_sdk_py.rest.rest_method import RestMethod
 class NamedRoute:
     def __init__(
         self,
-        method: RestMethod = None,
-        path: str = "",
-        unique_name: str = "",
+        method: RestMethod,
+        path: str,
+        unique_name: str,
     ):
         super().__init__()
         self.method = method
         self.path = path
         self.unique_name = unique_name
+        # Key for SDK handler registry.
+        self.key = f"{self.method.name} {self.path}"
 
     def __str__(self) -> str:
         return f"{self.method.name} {self.path} {self.unique_name}"

--- a/src/opensearch_sdk_py/transport/outbound_message_request.py
+++ b/src/opensearch_sdk_py/transport/outbound_message_request.py
@@ -16,7 +16,6 @@ from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
 from opensearch_sdk_py.transport.thread_context_struct import ThreadContextStruct
 from opensearch_sdk_py.transport.transport_message import TransportMessage
-from opensearch_sdk_py.transport.transport_status import TransportStatus
 from opensearch_sdk_py.transport.version import Version
 
 
@@ -34,7 +33,7 @@ class OutboundMessageRequest(OutboundMessage):
     ) -> None:
         self.features = features
         self.action = action
-        super().__init__(thread_context=thread_context, version=version, status=TransportStatus.STATUS_REQRES, request_id=request_id, message=message)
+        super().__init__(thread_context=thread_context, version=version, status=0, request_id=request_id, message=message)
         if is_handshake:
             self.tcp_header.is_handshake = True
         if is_compress:

--- a/tests/rest/test_extension_rest_handlers.py
+++ b/tests/rest/test_extension_rest_handlers.py
@@ -1,0 +1,38 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
+from opensearch_sdk_py.rest.extension_rest_handlers import ExtensionRestHandlers
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
+from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
+from opensearch_sdk_py.rest.named_route import NamedRoute
+from opensearch_sdk_py.rest.rest_method import RestMethod
+
+
+class TestExtensionRestHandlers(unittest.TestCase):
+    def test_registers_handler(self) -> None:
+        handlers = ExtensionRestHandlers()
+        handlers.register(FakeRestHandler())
+        self.assertEqual(len(ExtensionRestHandlers()), 2)
+        self.assertIsInstance(ExtensionRestHandlers()["GET /foo"], FakeRestHandler)
+        self.assertIsInstance(ExtensionRestHandlers()["GET /bar"], FakeRestHandler)
+        self.assertListEqual(ExtensionRestHandlers().named_routes(), ["GET /foo get_foo", "GET /bar get_bar"])
+
+
+class FakeRestHandler(ExtensionRestHandler):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
+        pass
+
+    def routes(self) -> list[NamedRoute]:
+        return [NamedRoute(RestMethod.GET, "/foo", "get_foo"), NamedRoute(RestMethod.GET, "/bar", "get_bar")]

--- a/tests/rest/test_extension_rest_request.py
+++ b/tests/rest/test_extension_rest_request.py
@@ -17,7 +17,7 @@ from opensearch_sdk_py.transport.stream_output import StreamOutput
 
 
 class TestExtensionRestRequest(unittest.TestCase):
-    def test_initialize_extension_request(self) -> None:
+    def test_extension_rest_request(self) -> None:
         err = ExtensionRestRequest(
             method=RestMethod.GET,
             uri="/hello?v",

--- a/tests/rest/test_extension_rest_response.py
+++ b/tests/rest/test_extension_rest_response.py
@@ -1,0 +1,42 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
+from opensearch_sdk_py.rest.rest_status import RestStatus
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class TestExtensionRestResponse(unittest.TestCase):
+    def test_initialize_extension_response(self) -> None:
+        err = ExtensionRestResponse()
+        self.assertEqual(err.content, b"")
+        self.assertEqual(err.content_type, ExtensionRestResponse.TEXT_CONTENT_TYPE)
+        self.assertListEqual(err.consumed_params, [])
+        self.assertFalse(err.content_consumed)
+
+        err = ExtensionRestResponse(status=RestStatus.OK, content=b"test", content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["foo", "bar"], content_consumed=True)
+        self.assertEqual(err.status, RestStatus.OK)
+        self.assertEqual(err.content, b"test")
+        self.assertEqual(err.content_type, ExtensionRestResponse.JSON_CONTENT_TYPE)
+        self.assertListEqual(err.consumed_params, ["foo", "bar"])
+        self.assertTrue(err.content_consumed)
+
+        output = StreamOutput()
+        err.write_to(output)
+
+        err = ExtensionRestResponse()
+        err.read_from(StreamInput(output.getvalue()))
+        self.assertEqual(err.status, RestStatus.OK)
+        self.assertEqual(err.content, b"test")
+        self.assertEqual(err.content_type, ExtensionRestResponse.JSON_CONTENT_TYPE)
+        self.assertListEqual(err.consumed_params, ["foo", "bar"])
+        self.assertTrue(err.content_consumed)

--- a/tests/rest/test_extension_rest_response.py
+++ b/tests/rest/test_extension_rest_response.py
@@ -20,13 +20,15 @@ class TestExtensionRestResponse(unittest.TestCase):
         err = ExtensionRestResponse()
         self.assertEqual(err.content, b"")
         self.assertEqual(err.content_type, ExtensionRestResponse.TEXT_CONTENT_TYPE)
+        self.assertDictEqual(err.headers, {})
         self.assertListEqual(err.consumed_params, [])
         self.assertFalse(err.content_consumed)
 
-        err = ExtensionRestResponse(status=RestStatus.OK, content=b"test", content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["foo", "bar"], content_consumed=True)
+        err = ExtensionRestResponse(status=RestStatus.OK, content=b"test", content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, headers={"foo": ["bar", "baz"]}, consumed_params=["foo", "bar"], content_consumed=True)
         self.assertEqual(err.status, RestStatus.OK)
         self.assertEqual(err.content, b"test")
         self.assertEqual(err.content_type, ExtensionRestResponse.JSON_CONTENT_TYPE)
+        self.assertDictEqual(err.headers, {"foo": ["bar", "baz"]})
         self.assertListEqual(err.consumed_params, ["foo", "bar"])
         self.assertTrue(err.content_consumed)
 
@@ -38,5 +40,6 @@ class TestExtensionRestResponse(unittest.TestCase):
         self.assertEqual(err.status, RestStatus.OK)
         self.assertEqual(err.content, b"test")
         self.assertEqual(err.content_type, ExtensionRestResponse.JSON_CONTENT_TYPE)
+        self.assertDictEqual(err.headers, {"foo": ["bar", "baz"]})
         self.assertListEqual(err.consumed_params, ["foo", "bar"])
         self.assertTrue(err.content_consumed)

--- a/tests/rest/test_named_route.py
+++ b/tests/rest/test_named_route.py
@@ -1,0 +1,22 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+from opensearch_sdk_py.rest.named_route import NamedRoute
+from opensearch_sdk_py.rest.rest_method import RestMethod
+
+
+class TestNamedRoute(unittest.TestCase):
+    def test_named_route(self) -> None:
+        nr = NamedRoute(method=RestMethod.GET, path="/test", unique_name="testing")
+        self.assertEqual(nr.method, RestMethod.GET)
+        self.assertEqual(nr.path, "/test")
+        self.assertEqual(nr.unique_name, "testing")
+        self.assertEqual(str(nr), "GET /test testing")

--- a/tests/rest/test_rest_execute_on_extension_response.py
+++ b/tests/rest/test_rest_execute_on_extension_response.py
@@ -16,7 +16,7 @@ from opensearch_sdk_py.transport.stream_output import StreamOutput
 
 
 class TestRestExecuteOnExtensionResponse(unittest.TestCase):
-    def test_initialize_extension_request(self) -> None:
+    def test_rest_execute_on_extension_request(self) -> None:
         reoer = RestExecuteOnExtensionResponse(status=RestStatus.OK, content_type="application/json; charset=utf-8", content=bytes("{}", "ascii"), headers={"foo": ["bar", "baz"]}, consumed_params=["bar", "baz"], content_consumed=True)
         self.assertEqual(reoer.status, RestStatus.OK)
         self.assertEqual(reoer.content_type, "application/json; charset=utf-8")

--- a/tests/transport/test_outbound_message_request.py
+++ b/tests/transport/test_outbound_message_request.py
@@ -26,8 +26,8 @@ class TestOutboundMessageRequest(unittest.TestCase):
         self.assertEqual(omr.action, "")
         self.assertEqual(omr.request_id, 42)
         self.assertEqual(omr.version.id, 136317827)
-        self.assertFalse(omr.is_request)
-        self.assertTrue(omr.is_response)
+        self.assertTrue(omr.is_request)
+        self.assertFalse(omr.is_response)
         self.assertFalse(omr.is_error)
         self.assertFalse(omr.is_compress)
         self.assertFalse(omr.is_handshake)
@@ -58,7 +58,7 @@ class TestOutboundMessageRequest(unittest.TestCase):
 
         self.assertEqual(
             out.getvalue(),
-            b"ES\x00\x00\x00\x3a\x00\x00\x00\x00\x00\x00\x00\x02\t\x08\x2d\xc7\x23\x00\x00\x00\x23"  # tcp header
+            b"ES\x00\x00\x00\x3a\x00\x00\x00\x00\x00\x00\x00\x02\x08\x08\x2d\xc7\x23\x00\x00\x00\x23"  # tcp header
             + b"\x00\x00"  # context
             + b"\x02\x03foo\x03bar"  # features
             + b"\x17internal:test/handshake"  # action


### PR DESCRIPTION
### Description

Creates Interface classes for the Extension and Rest Handler.  Uses `routes()` on the handler object to register the handlers both on SDK side and on OpenSearch.  Calls the appropriate handler when an incoming Rest Request is received.

```
$ curl -XGET "localhost:9200/_extensions/_hello-world/hello"
Hello from Python! 👋%      
```

### Issues Resolved

Fixes #8 
Fixes an unreported bug where OutboundMessageRequest was encoded as a response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
