### PR TITLE
Calculate ThreadContextStruct size without writing to stream

### DIFF
--- a/src/opensearch_sdk_py/transport/stream_output.py
+++ b/src/opensearch_sdk_py/transport/stream_output.py
@@ -9,6 +9,7 @@
 
 from enum import Enum
 from io import BytesIO
+from typing import Union
 
 from opensearch_sdk_py.transport.version import Version
 
@@ -390,6 +391,16 @@ class StreamOutput(BytesIO):
             self.write_string(k)
             self.write_string(d[k])
 
+    @classmethod
+    def string_to_string_dict_size(self, d: dict[str, str]) -> int:
+        result: int = StreamOutput.v_int_size(len(d))
+        for k, v in d.items():
+            result += StreamOutput.v_int_size(len(k))
+            result += len(bytes(k, "utf-8"))
+            result += StreamOutput.v_int_size(len(v))
+            result += len(bytes(v, "utf-8"))
+        return result
+
     def write_string_to_string_array_dict(self, d: dict[str, list[str]]) -> None:
         self.write_v_int(len(d))
         for k in d:
@@ -401,6 +412,18 @@ class StreamOutput(BytesIO):
         for k in d:
             self.write_string(k)
             self.write_string_set(d[k])
+
+    @classmethod
+    def string_to_string_collection_dict_size(self, d: dict[str, Union[list[str], set[str]]]) -> int:
+        result: int = StreamOutput.v_int_size(len(d))
+        for k, v in d.items():
+            result += StreamOutput.v_int_size(len(k))
+            result += len(bytes(k, "utf-8"))
+            result += StreamOutput.v_int_size(len(v))
+            for s in v:
+                result += StreamOutput.v_int_size(len(s))
+                result += len(bytes(s, "utf-8"))
+        return result
 
     # /**
     #  write map to stream with consistent order

--- a/src/opensearch_sdk_py/transport/thread_context_struct.py
+++ b/src/opensearch_sdk_py/transport/thread_context_struct.py
@@ -30,20 +30,8 @@ class ThreadContextStruct:
 
     @property
     def size(self) -> int:
-        size: int = StreamOutput.v_int_size(len(self.request_headers))
-        for k, h in self.request_headers.items():
-            size += StreamOutput.v_int_size(len(k))
-            size += len(bytes(k, "utf-8"))
-            size += StreamOutput.v_int_size(len(h))
-            size += len(bytes(h, "utf-8"))
-        size += StreamOutput.v_int_size(len(self.response_headers))
-        for k, v in self.response_headers.items():
-            size += StreamOutput.v_int_size(len(k))
-            size += len(bytes(k, "utf-8"))
-            size += StreamOutput.v_int_size(len(v))
-            for h in v:
-                size += StreamOutput.v_int_size(len(h))
-                size += len(bytes(h, "utf-8"))
+        size: int = StreamOutput.string_to_string_dict_size(self.request_headers)
+        size += StreamOutput.string_to_string_collection_dict_size(self.response_headers)
         return size
 
     def __str__(self) -> str:

--- a/tests/transport/test_stream_output.py
+++ b/tests/transport/test_stream_output.py
@@ -123,6 +123,7 @@ class TestStreamOutput(unittest.TestCase):
         out = StreamOutput()
         out.write_string_to_string_dict(d)
         self.assertEqual(out.getvalue(), b"\x02\x03foo\x03bar\x03baz\x03qux")
+        self.assertEqual(StreamOutput.string_to_string_dict_size(d), len(out.getvalue()))
 
     def test_write_string_to_string_array_dict(self) -> None:
         d = dict()
@@ -131,6 +132,7 @@ class TestStreamOutput(unittest.TestCase):
         out = StreamOutput()
         out.write_string_to_string_array_dict(d)
         self.assertEqual(out.getvalue(), b"\x02\x03foo\x02\x03bar\x03baz\x03qux\x00")
+        self.assertEqual(StreamOutput.string_to_string_collection_dict_size(d), len(out.getvalue()))
 
     def test_write_string_to_string_set_dict(self) -> None:
         d: dict[str, Any] = dict()
@@ -145,6 +147,7 @@ class TestStreamOutput(unittest.TestCase):
                 b"\x02\x03foo\x02\x03baz\x03bar\x03qux\x00",
             ],
         )
+        self.assertEqual(StreamOutput.string_to_string_collection_dict_size(d), len(out.getvalue()))
 
     def test_write_enum(self) -> None:
         TestEnum = Enum("TestEnum", ["FOO", "BAR", "BAZ"], start=0)

--- a/tests/transport/test_thread_context_struct.py
+++ b/tests/transport/test_thread_context_struct.py
@@ -49,3 +49,13 @@ class TestThreadContextStruct(unittest.TestCase):
         tcs.read_from(StreamInput(b"\x00\x00"))
         self.assertEqual(len(tcs.request_headers), 0)
         self.assertEqual(len(tcs.response_headers), 0)
+
+    def test_thread_context_struct_size(self) -> None:
+        tcs = ThreadContextStruct()
+        self.assertEqual(tcs.size, 2)
+
+        tcs.request_headers["foo"] = "bar"
+        self.assertEqual(tcs.size, 10)
+
+        tcs.response_headers["baz"] = {"qux", "quux"}
+        self.assertEqual(tcs.size, 24)


### PR DESCRIPTION
### Description

Calculates the byte size of the ThreadContextStruct maps without needing to write them to StreamOutput.

Tests were written and passed based on previous implementation.

### Issues Resolved

Resolves a TODO in the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
