### PR TITLE
Error handling for request not found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,6 @@ jobs:
           poetry run coverage run --source=src -m pytest -v
           poetry run coverage xml
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml

--- a/src/opensearch_sdk_py/actions/internal/request_error_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/request_error_handler.py
@@ -1,0 +1,45 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+from opensearch_sdk_py.actions.request_handler import RequestHandler
+from opensearch_sdk_py.rest.rest_execute_on_extension_response import RestExecuteOnExtensionResponse
+from opensearch_sdk_py.rest.rest_status import RestStatus
+from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class RequestErrorHandler(RequestHandler):
+    def __init__(
+        self,
+        status: RestStatus,
+        content: bytes,
+        content_type: str,
+    ):
+        self.status = status
+        self.content = content
+        self.content_type = content_type
+
+    def handle(self, request: OutboundMessageRequest, input: StreamInput) -> StreamOutput:
+        self.send(
+            OutboundMessageResponse(
+                request.thread_context_struct,
+                request.features,
+                RestExecuteOnExtensionResponse(
+                    status=self.status,
+                    content_type=self.content_type,
+                    content=self.content,
+                ),
+                request.version,
+                request.request_id,
+                request.is_handshake,
+                request.is_compress,
+            )
+        )

--- a/src/opensearch_sdk_py/actions/internal/request_error_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/request_error_handler.py
@@ -28,7 +28,7 @@ class RequestErrorHandler(RequestHandler):
         self.content_type = content_type
 
     def handle(self, request: OutboundMessageRequest, input: StreamInput) -> StreamOutput:
-        self.send(
+        return self.send(
             OutboundMessageResponse(
                 request.thread_context_struct,
                 request.features,

--- a/src/opensearch_sdk_py/rest/extension_rest_handlers.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handlers.py
@@ -10,16 +10,9 @@
 import logging
 from typing import Dict
 
-from opensearch_sdk_py.actions.request_handler import RequestHandler
 from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
 from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
 from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
-from opensearch_sdk_py.rest.rest_execute_on_extension_response import RestExecuteOnExtensionResponse
-from opensearch_sdk_py.rest.rest_status import RestStatus
-from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
-from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
-from opensearch_sdk_py.transport.stream_input import StreamInput
-from opensearch_sdk_py.transport.stream_output import StreamOutput
 
 
 class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
@@ -49,35 +42,4 @@ class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
         return self._named_routes
 
     def handle(self, route: str, request: ExtensionRestRequest) -> ExtensionRestResponse:
-        if route in self:
-            return getattr(self[route], "handle_request")(request)
-        return ErrorHandler(status=RestStatus.NOT_FOUND, content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, content=bytes(f'{{"error": "No handler found for {request.method.name} {request.path}"}}', "utf-8"))
-
-
-class ErrorHandler(RequestHandler):
-    def __init__(
-        self,
-        status: RestStatus,
-        content: bytes,
-        content_type: str,
-    ):
-        self.status = status
-        self.content = content
-        self.content_type = content_type
-
-    def handle(self, request: OutboundMessageRequest, input: StreamInput) -> StreamOutput:
-        self.send(
-            OutboundMessageResponse(
-                request.thread_context_struct,
-                request.features,
-                RestExecuteOnExtensionResponse(
-                    status=self.status,
-                    content_type=self.content_type,
-                    content=self.content,
-                ),
-                request.version,
-                request.request_id,
-                request.is_handshake,
-                request.is_compress,
-            )
-        )
+        return getattr(self[route], "handle_request")(request)

--- a/tests/actions/internal/test_request_error_handler.py
+++ b/tests/actions/internal/test_request_error_handler.py
@@ -1,0 +1,49 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+from opensearch_sdk_py.actions.internal.request_error_handler import RequestErrorHandler
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
+from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
+from opensearch_sdk_py.rest.http_version import HttpVersion
+from opensearch_sdk_py.rest.rest_execute_on_extension_response import RestExecuteOnExtensionResponse
+from opensearch_sdk_py.rest.rest_method import RestMethod
+from opensearch_sdk_py.rest.rest_status import RestStatus
+from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.version import Version
+
+
+class TestRequestErrorHandler(unittest.TestCase):
+    def test_request_error_handler(self) -> None:
+        reh = RequestErrorHandler(status=RestStatus.NOT_FOUND, content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, content=bytes('{{"error": "test"}}', "utf-8"))
+        self.assertEqual(RestStatus.NOT_FOUND, reh.status)
+        self.assertEqual(ExtensionRestResponse.JSON_CONTENT_TYPE, reh.content_type)
+        self.assertEqual('{{"error": "test"}}', str(reh.content, "utf-8"))
+
+        omr = OutboundMessageRequest(
+            message=ExtensionRestRequest(
+                method=RestMethod.GET,
+                path="/test",
+                http_version=HttpVersion.HTTP_1_1,
+            ),
+            version=Version(Version.CURRENT),
+        )
+        output = reh.handle(omr, None)
+
+        input = StreamInput(output.getvalue())
+        response = OutboundMessageResponse()
+        response.read_from(input)
+        message = RestExecuteOnExtensionResponse()
+        message.read_from(input)
+        self.assertEqual(RestStatus.NOT_FOUND, message.status)
+        self.assertEqual(ExtensionRestResponse.JSON_CONTENT_TYPE, message.content_type)
+        self.assertIn("test", str(message.content, "utf-8"))

--- a/tests/rest/test_extension_rest_handlers.py
+++ b/tests/rest/test_extension_rest_handlers.py
@@ -34,9 +34,6 @@ class TestExtensionRestHandlers(unittest.TestCase):
         response = handlers.handle("GET /foo", ExtensionRestRequest())
         self.assertEqual(response.status, RestStatus.NOT_IMPLEMENTED)
 
-        response = handlers.handle("GET /baz", ExtensionRestRequest(method=RestMethod.GET))
-        self.assertEqual(response.status, RestStatus.NOT_FOUND)
-
 
 class FakeRestHandler(ExtensionRestHandler):
     def __init__(self) -> None:

--- a/tests/rest/test_extension_rest_handlers.py
+++ b/tests/rest/test_extension_rest_handlers.py
@@ -34,6 +34,9 @@ class TestExtensionRestHandlers(unittest.TestCase):
         response = handlers.handle("GET /foo", ExtensionRestRequest())
         self.assertEqual(response.status, RestStatus.NOT_IMPLEMENTED)
 
+        response = handlers.handle("GET /baz", ExtensionRestRequest(method=RestMethod.GET))
+        self.assertEqual(response.status, RestStatus.NOT_FOUND)
+
 
 class FakeRestHandler(ExtensionRestHandler):
     def __init__(self) -> None:


### PR DESCRIPTION
### Description

Handles the case where a Rest Request with unhandled path makes it to an extension.

Normally, this should never actually happen™️.  Any path sent to the RestController on OpenSearch should already be handled on the SDK side.

### Issues Resolved

Fixes a TODO in the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
