### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,6 @@ jobs:
           poetry run coverage run --source=src -m pytest -v
           poetry run coverage xml
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml


### PR DESCRIPTION
Reverts opensearch-project/opensearch-sdk-py#34

Apparently v4 is in beta, and the latest version is `v4.0.0-beta.2` which `v4` doesn't resolve to.  It also has a breaking change regarding upload tokens.   Going back to v3 for now.