### PR TITLE
Fix: hello matching request handlers by name.

### DIFF
--- a/src/opensearch_sdk_py/rest/extension_rest_handlers.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handlers.py
@@ -42,4 +42,4 @@ class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
         return self._named_routes
 
     def handle(self, route: str, request: ExtensionRestRequest) -> ExtensionRestResponse:
-        return getattr(self[route], "handle_request")(request)
+        return self[route].handle_request(request)


### PR DESCRIPTION
### Description

The `RequestHandlers` instance is a `Dict`, but not the class, those methods are no longer static.

### Issues Resolved

Also closes #40.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
