### PR TITLE
Use assertEqual for arrays.

### DIFF
--- a/tests/protobuf/test_register_rest_actions_proto.py
+++ b/tests/protobuf/test_register_rest_actions_proto.py
@@ -23,9 +23,5 @@ class TestRegisterRestActionsProto_pb2(unittest.TestCase):
         parsed_actions = RegisterRestActionsProto_pb2.RegisterRestActions()
         parsed_actions.ParseFromString(serialized_str)
         self.assertEqual(parsed_actions.identity.uniqueId, actions.identity.uniqueId)
-        self.assertCountEqual(parsed_actions.restActions, actions.restActions)
-        for i in range(len(actions.restActions)):
-            self.assertEqual(parsed_actions.restActions[i], actions.restActions[i])
-        self.assertCountEqual(parsed_actions.restActions, actions.restActions)
-        for i in range(len(actions.deprecatedRestActions)):
-            self.assertEqual(parsed_actions.deprecatedRestActions[i], actions.deprecatedRestActions[i])
+        self.assertEqual(parsed_actions.restActions, actions.restActions)
+        self.assertEqual(parsed_actions.deprecatedRestActions, actions.deprecatedRestActions)


### PR DESCRIPTION
### Description

Yes, it's simple.

Coming from https://github.com/opensearch-project/opensearch-sdk-py/pull/44#discussion_r1328298829.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
