### PR TITLE
Removed default constructors.

### DIFF
--- a/src/opensearch_sdk_py/transport/transport_message.py
+++ b/src/opensearch_sdk_py/transport/transport_message.py
@@ -14,9 +14,6 @@ from opensearch_sdk_py.transport.stream_output import StreamOutput
 
 
 class TransportMessage:
-    def __init__(self) -> None:
-        pass
-
     def read_from(self, input: StreamInput) -> "TransportMessage":
         return self
 

--- a/src/opensearch_sdk_py/transport/transport_response.py
+++ b/src/opensearch_sdk_py/transport/transport_response.py
@@ -13,9 +13,6 @@ from opensearch_sdk_py.transport.transport_message import TransportMessage
 
 
 class TransportResponse(TransportMessage):
-    def __init__(self) -> None:
-        super().__init__()
-
     def read_from(self, input: StreamInput) -> "TransportResponse":
         return self
 

--- a/tests/rest/test_extension_rest_handler.py
+++ b/tests/rest/test_extension_rest_handler.py
@@ -22,8 +22,5 @@ class TestExtensionRestHandler(unittest.TestCase):
 
 
 class DefaultRestHandler(ExtensionRestHandler):
-    def __init__(self) -> None:
-        super().__init__()
-
     def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
         return ExtensionRestResponse(status=RestStatus.NOT_IMPLEMENTED)

--- a/tests/rest/test_extension_rest_handlers.py
+++ b/tests/rest/test_extension_rest_handlers.py
@@ -36,9 +36,6 @@ class TestExtensionRestHandlers(unittest.TestCase):
 
 
 class FakeRestHandler(ExtensionRestHandler):
-    def __init__(self) -> None:
-        super().__init__()
-
     def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
         return ExtensionRestResponse(status=RestStatus.NOT_IMPLEMENTED)
 

--- a/tests/transport/test_outbound_message_request.py
+++ b/tests/transport/test_outbound_message_request.py
@@ -108,9 +108,6 @@ class TestOutboundMessageRequest(unittest.TestCase):
 
 
 class FakeTransportRequest(TransportRequest):
-    def __init__(self) -> None:
-        super().__init__()
-
     def write_to(self, output: StreamOutput) -> None:
         super().write_to(output)
         output.write_string("test")

--- a/tests/transport/test_outbound_message_response.py
+++ b/tests/transport/test_outbound_message_response.py
@@ -72,9 +72,6 @@ class TestOutboundMessageResponse(unittest.TestCase):
 
 
 class FakeTransportResponse(TransportResponse):
-    def __init__(self) -> None:
-        super().__init__()
-
     def write_to(self, output: StreamOutput) -> None:
         super().write_to(output)
         output.write_string("test")


### PR DESCRIPTION
### Description

The default constructor calls `super().__init__()` anyway, so this code is not needed.

### Issues Resolved

Coming from https://github.com/opensearch-project/opensearch-sdk-py/pull/44#discussion_r1328300483.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
