### PR TITLE
Extract async host.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,5 @@ repos:
         name: pytest
         entry: bash -c 'poetry run pytest'
         language: system
+        pass_filenames: false
+        always_run: true

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -8,10 +8,7 @@
 # compatible open source license.
 #
 
-import asyncio
 import logging
-import socket
-from typing import Any
 
 from hello_extension import HelloExtension
 
@@ -20,6 +17,7 @@ from opensearch_sdk_py.actions.internal.request_error_handler import RequestErro
 from opensearch_sdk_py.actions.request_handlers import RequestHandlers
 from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
 from opensearch_sdk_py.rest.rest_status import RestStatus
+from opensearch_sdk_py.server.async_host import AsyncHost
 from opensearch_sdk_py.transport.acknowledged_response import AcknowledgedResponse
 from opensearch_sdk_py.transport.initialize_extension_response import InitializeExtensionResponse
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
@@ -29,71 +27,43 @@ from opensearch_sdk_py.transport.stream_output import StreamOutput
 from opensearch_sdk_py.transport.tcp_header import TcpHeader
 
 
-async def handle_connection(conn: Any, loop: asyncio.AbstractEventLoop) -> None:
-    try:
-        conn.setblocking(False)
+class HelloExtensionHost(AsyncHost):
+    def on_input(self, input: StreamInput) -> StreamOutput:
         request_handlers = RequestHandlers()
+        header = TcpHeader().read_from(input)
+        logging.debug(f"< {header}")
 
-        while raw := await loop.sock_recv(conn, 1024 * 10):
-            input = StreamInput(raw)
-            logging.debug(f"< #{str(raw)}, size={len(raw)} byte(s)")
-
-            header = TcpHeader().read_from(input)
-            logging.debug(f"< {header}")
-
-            if header.is_request:
-                request: OutboundMessageRequest = OutboundMessageRequest().read_from(input, header)
-                logging.info(f"< {request}")
-                if request.action in request_handlers:
-                    output = request_handlers.handle(request, input)
-                else:
-                    output = RequestErrorHandler(status=RestStatus.NOT_FOUND, content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, content=bytes(f'{{"error": "No handler found for {request.method.name} {request.path}"}}', "utf-8")).handle(
-                        request, input
-                    )
+        if header.is_request:
+            request: OutboundMessageRequest = OutboundMessageRequest().read_from(input, header)
+            logging.info(f"< {request}")
+            if request.action in request_handlers:
+                output = request_handlers.handle(request, input)
             else:
-                response = OutboundMessageResponse().read_from(input, header)
-                # TODO: Error handling
-                if response.is_error:
-                    output = None
-                    logging.warn(f"< error {header}")
-                else:
-                    ack_response = AcknowledgedResponse().read_from(input)
-                    logging.debug(f"< response {response}, {ack_response}")
-                    output = StreamOutput()
-                    response = OutboundMessageResponse(
-                        response.thread_context_struct,
-                        response.features,
-                        InitializeExtensionResponse("hello-world", ["Extension", "ActionExtension"]),
-                        response.version,
-                        DiscoveryExtensionsRequestHandler.init_response_request_id,
-                        response.is_handshake,
-                        response.is_compress,
-                    )
-                    response.write_to(output)
-                    logging.info(f"> {response}")
-
-            if output:
-                await loop.sock_sendall(conn, output.getvalue())
-
-    except Exception as ex:
-        logging.exception(ex)
-    finally:
-        conn.close()
-
-
-async def run_server() -> None:
-    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    server.bind(("localhost", 1234))
-    server.setblocking(False)
-    server.listen()
-
-    loop = asyncio.get_event_loop()
-
-    logging.info(f"< server={server}")
-    while True:
-        conn, _ = await loop.sock_accept(server)
-        logging.debug(f"< connection={conn}")
-        loop.create_task(handle_connection(conn, loop))
+                output = RequestErrorHandler(status=RestStatus.NOT_FOUND, content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, content=bytes(f'{{"error": "No handler found for {request.method.name} {request.path}"}}', "utf-8")).handle(
+                    request, input
+                )
+        else:
+            response = OutboundMessageResponse().read_from(input, header)
+            # TODO: Error handling
+            if response.is_error:
+                output = None
+                logging.warn(f"< error {header}")
+            else:
+                ack_response = AcknowledgedResponse().read_from(input)
+                logging.debug(f"< response {response}, {ack_response}")
+                output = StreamOutput()
+                response = OutboundMessageResponse(
+                    response.thread_context_struct,
+                    response.features,
+                    InitializeExtensionResponse("hello-world", ["Extension", "ActionExtension"]),
+                    response.version,
+                    DiscoveryExtensionsRequestHandler.init_response_request_id,
+                    response.is_handshake,
+                    response.is_compress,
+                )
+                response.write_to(output)
+                logging.info(f"> {response}")
+        return output
 
 
 logging.basicConfig(encoding="utf-8", level=logging.INFO)
@@ -102,6 +72,5 @@ logging.basicConfig(encoding="utf-8", level=logging.INFO)
 extension = HelloExtension()
 logging.info(f"Starting {extension} that implements {extension.implemented_interfaces}.")
 
-# Back to your regularly scheduled asyncio.
-# TODO: move this loop to SDK
-asyncio.run(run_server())
+host = HelloExtensionHost()
+host.run()

--- a/src/opensearch_sdk_py/server/__init__.py
+++ b/src/opensearch_sdk_py/server/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#

--- a/src/opensearch_sdk_py/server/async_host.py
+++ b/src/opensearch_sdk_py/server/async_host.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import asyncio
+import logging
+import socket
+from abc import abstractmethod
+from typing import Any
+
+from opensearch_sdk_py.server.host import Host
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class AsyncHost(Host):
+    def run(self) -> None:
+        asyncio.run(self.async_run())
+
+    async def async_run(self) -> None:
+        self.terminating = False
+        self.server = self.__listen()
+        loop = asyncio.get_event_loop()
+        logging.info(f"< server={self.server}")
+        while not self.terminating:
+            try:
+                self.future = asyncio.ensure_future(loop.sock_accept(self.server))
+                conn = (await self.future)[0]
+                conn.setblocking(False)
+                logging.debug(f"< connection={conn}")
+                loop.create_task(self.on_connection(conn))
+            except asyncio.exceptions.CancelledError:
+                pass
+
+    async def on_connection(self, conn: Any) -> None:
+        try:
+            loop = asyncio.get_event_loop()
+            while raw := await loop.sock_recv(conn, 1024 * 10):
+                input = StreamInput(raw)
+                logging.debug(f"< #{str(raw)}, size={len(raw)} byte(s)")
+                output = self.on_input(input)
+                if output:
+                    data = output.getvalue()
+                    logging.debug(f"> #{str(data)}, size={len(data)} byte(s)")
+                    await loop.sock_sendall(conn, data)
+                if self.terminating:
+                    logging.debug("| terminating")
+                    self.future.cancel()
+                    break
+        # except Exception as ex:
+        #     logging.exception(ex)
+        finally:
+            conn.close()
+
+    def __listen(self) -> socket.socket:
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind((self.address, self.port))
+        server.setblocking(False)
+        server.listen()
+        return server
+
+    @abstractmethod
+    def on_input(self, input: StreamInput) -> StreamOutput:
+        pass  # pragma: no cover

--- a/src/opensearch_sdk_py/server/host.py
+++ b/src/opensearch_sdk_py/server/host.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+
+from abc import ABC, abstractmethod
+
+
+class Host(ABC):
+    def __init__(self, address: str = "localhost", port: int = 1234) -> None:
+        self.address = address
+        self.port = port
+
+    @abstractmethod
+    def run(self) -> None:
+        pass  # pragma: no cover

--- a/tests/server/__init__.py
+++ b/tests/server/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#

--- a/tests/server/test_async_host.py
+++ b/tests/server/test_async_host.py
@@ -1,0 +1,61 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import asyncio
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from opensearch_sdk_py.server.async_host import AsyncHost
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class TestAsyncHost(unittest.TestCase):
+    class MyAsyncHost(AsyncHost):
+        def on_input(self, input: StreamInput) -> StreamOutput:
+            command = input.read_string()
+            if command == "QUIT":
+                self.terminating = True
+            response = StreamOutput()
+            response.write_string("OK")
+            return response
+
+    def setUp(self) -> None:
+        self.host = TestAsyncHost.MyAsyncHost()
+        return super().setUp()
+
+    def test_init(self) -> None:
+        self.assertEqual(self.host.address, "localhost")
+        self.assertEqual(self.host.port, 1234)
+
+    @patch("opensearch_sdk_py.server.async_host.AsyncHost.async_run")
+    def test_run_calls_async_run(self, mock_async_run: Any) -> None:
+        self.host.run()
+        self.assertTrue(mock_async_run.called)
+
+    async def __client(self) -> Any:
+        reader, writer = await asyncio.open_connection(self.host.address, self.host.port)
+        output = StreamOutput()
+        output.write_string("QUIT")
+        writer.write(output.getvalue())
+        response = StreamInput(await reader.read())
+        return response.read_string()
+
+    async def __server(self) -> None:
+        await self.host.async_run()
+
+    async def __both(self) -> Any:
+        return await asyncio.gather(*[self.__server(), self.__client()])
+
+    def test_run(self) -> None:
+        loop = asyncio.get_event_loop()
+        results = loop.run_until_complete(self.__both())
+        self.assertEqual(results[1], "OK")
+        loop.close()

--- a/tests/server/test_host.py
+++ b/tests/server/test_host.py
@@ -1,0 +1,23 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+from opensearch_sdk_py.server.host import Host
+
+
+class TestHost(unittest.TestCase):
+    class MyHost(Host):
+        def run(self) -> None:
+            pass
+
+    def test_init(self) -> None:
+        host = TestHost.MyHost()
+        self.assertEqual(host.address, "localhost")
+        self.assertEqual(host.port, 1234)


### PR DESCRIPTION
### Description

- Extract async host class(es) and adds a test that performs a client-server conversation with graceful termination.
- Fixed pre-commit running pytest multiple times, with this change it would fail on port already used when run too fast, see https://stackoverflow.com/a/75674157.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
