### PR TITLE
Misc.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -168,6 +168,8 @@ $ poetry run coverage report
 TOTAL 1207 79 93%
 ```
 
+You can run a combination of these by installing [poetry-exec-plugin](https://github.com/keattang/poetry-exec-plugin) once and using the `poetry exec coverage` shortcut.
+
 ## License Headers
 
 All python code has a copy of the [license header](LICENSE_HEADER.txt) on top of it. To bulk apply license headers use `poetry run licenseheaders -t LICENSE_HEADER.txt -E .py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,4 +70,5 @@ integration = """
 coverage = """
   poetry run coverage run --source=src -m pytest
   poetry run coverage report
+  poetry run coverage html
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,7 @@ auto = """
 integration = """
   poetry run pytest samples/hello/tests
 """
+coverage = """
+  poetry run coverage run --source=src -m pytest
+  poetry run coverage report
+"""

--- a/samples/hello/hello.py
+++ b/samples/hello/hello.py
@@ -19,7 +19,7 @@ logging.basicConfig(encoding="utf-8", level=logging.INFO)
 extension = HelloExtension()
 logging.info(f"Starting {extension} that implements {extension.implemented_interfaces}.")
 
-host = AsyncExtensionHost()
+host = AsyncExtensionHost(port=1234)
 host.serve(extension)
 
 logging.info(f"Listening on {host.address}:{host.port}.")

--- a/src/opensearch_sdk_py/server/host.py
+++ b/src/opensearch_sdk_py/server/host.py
@@ -10,10 +10,13 @@
 
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
 
 class Host(ABC):
-    def __init__(self, address: str = "localhost", port: int = 1234) -> None:
+    port: Optional[int] = None
+
+    def __init__(self, address: str = "localhost", port: Optional[int] = None) -> None:
         self.address = address
         self.port = port
 

--- a/src/opensearch_sdk_py/transport/outbound_message.py
+++ b/src/opensearch_sdk_py/transport/outbound_message.py
@@ -9,7 +9,7 @@
 
 # https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/transport/OutboundMessage.java
 
-from typing import Optional
+from typing import Any, Optional, Union
 
 from opensearch_sdk_py.transport.network_message import NetworkMessage
 from opensearch_sdk_py.transport.stream_input import StreamInput
@@ -96,3 +96,8 @@ class OutboundMessage(NetworkMessage):
 
     def __str__(self) -> str:
         return f"{super().__str__()}, {self.message.__str__()}"
+
+    def __bytes__(self) -> Union[Any, bytes]:
+        output = StreamOutput()
+        self.write_to(output)
+        return output.getvalue()

--- a/tests/server/test_async_host.py
+++ b/tests/server/test_async_host.py
@@ -32,7 +32,7 @@ class TestAsyncHost(unittest.TestCase):
 
     def test_init(self) -> None:
         self.assertEqual(self.host.address, "localhost")
-        self.assertEqual(self.host.port, 1234)
+        self.assertIsNone(self.host.port)
 
     @patch("opensearch_sdk_py.server.async_host.AsyncHost.async_run")
     def test_run_calls_async_run(self, mock_async_run: Any) -> None:

--- a/tests/server/test_host.py
+++ b/tests/server/test_host.py
@@ -20,4 +20,4 @@ class TestHost(unittest.TestCase):
     def test_init(self) -> None:
         host = TestHost.MyHost()
         self.assertEqual(host.address, "localhost")
-        self.assertEqual(host.port, 1234)
+        self.assertIsNone(host.port)

--- a/tests/transport/test_outbound_message.py
+++ b/tests/transport/test_outbound_message.py
@@ -56,12 +56,15 @@ class TestOutboundMessage(unittest.TestCase):
     def test_outbound_message_variable_bytes(self) -> None:
         om = OutboundMessage()
         self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION)
+        self.assertEqual(om.tcp_header.variable_header_size, om.thread_context_struct.size)
         om.variable_bytes = b"\x01\x02\x03"
         self.assertEqual(om.variable_bytes, b"\x01\x02\x03")
         self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION + 3)
+        self.assertEqual(om.tcp_header.variable_header_size, om.thread_context_struct.size + 3)
         om.variable_bytes = b"\x01\x02\x03\x04"
         self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION + 4)
         self.assertEqual(om.variable_bytes, b"\x01\x02\x03\x04")
+        self.assertEqual(om.tcp_header.variable_header_size, om.thread_context_struct.size + 4)
 
     def test_outbound_message_message_bytes(self) -> None:
         om = OutboundMessage()

--- a/tests/transport/test_outbound_message.py
+++ b/tests/transport/test_outbound_message.py
@@ -52,3 +52,23 @@ class TestOutboundMessage(unittest.TestCase):
         )
         self.assertEqual(om.tcp_header.variable_header_size, 5)  # 2 for context, 3 for subclass
         self.assertEqual(om.tcp_header.size + TcpHeader.BYTES_REQUIRED_FOR_MESSAGE_SIZE - TcpHeader.HEADER_SIZE, om.tcp_header.variable_header_size + len(bytes(TransportRequest())))
+
+    def test_outbound_message_variable_bytes(self) -> None:
+        om = OutboundMessage()
+        self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION)
+        om.variable_bytes = b"\x01\x02\x03"
+        self.assertEqual(om.variable_bytes, b"\x01\x02\x03")
+        self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION + 3)
+        om.variable_bytes = b"\x01\x02\x03\x04"
+        self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION + 4)
+        self.assertEqual(om.variable_bytes, b"\x01\x02\x03\x04")
+
+    def test_outbound_message_message_bytes(self) -> None:
+        om = OutboundMessage()
+        self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION)
+        om.message_bytes = b"\x01\x02\x03"
+        self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION + 3)
+        self.assertEqual(om.message_bytes, b"\x01\x02\x03")
+        om.message_bytes = b"\x01\x02\x03\x04"
+        self.assertEqual(om.tcp_header.size, TcpHeader.VARIABLE_HEADER_SIZE_POSITION + 4)
+        self.assertEqual(om.message_bytes, b"\x01\x02\x03\x04")


### PR DESCRIPTION
### Description

1. Added `poetry exec coverage`.
2. Bind tests to the first available port by passing `port = None`.
3. Added some test coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
