### PR TITLE
Implement response handlers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           poetry install
           protoc -I=$PROTOBUF_SRC_DIR --python_out=$PROTOBUF_SRC_DIR $PROTOBUF_SRC_DIR/*.proto
           2to3 --no-diff -n -w $PROTOBUF_SRC_DIR
+          find $PROTOBUF_SRC_DIR -type f -name "*_pb2.py" | xargs sed -i.bak -E 's/(USE_C_DESCRIPTORS == False:)/\1  # pragma: no cover/g'
           poetry run coverage run --source=src -m pytest -v
           poetry run coverage xml
       - name: Upload Coverage Report

--- a/src/opensearch_sdk_py/actions/internal/discovery_extensions_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/discovery_extensions_request_handler.py
@@ -9,36 +9,58 @@
 
 import logging
 
+from opensearch_sdk_py.actions.internal.register_rest_actions_response_handler import RegisterRestActionsResponseHandler
 from opensearch_sdk_py.actions.request_handler import RequestHandler
+from opensearch_sdk_py.actions.response_handlers import ResponseHandlers
 from opensearch_sdk_py.api.action_extension import ActionExtension
 from opensearch_sdk_py.transport.initialize_extension_request import InitializeExtensionRequest
+from opensearch_sdk_py.transport.initialize_extension_response import InitializeExtensionResponse
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.register_rest_actions_request import RegisterRestActionsRequest
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
 
 
 class DiscoveryExtensionsRequestHandler(RequestHandler):
-    def __init__(self, extension: ActionExtension) -> None:
+    def __init__(self, extension: ActionExtension, response_handlers: ResponseHandlers) -> None:
         super().__init__("internal:discovery/extensions", extension)
+        self.response_handlers = response_handlers
 
     def handle(self, request: OutboundMessageRequest, input: StreamInput) -> StreamOutput:
         initialize_extension_request = InitializeExtensionRequest().read_from(input)
         logging.debug(f"< {initialize_extension_request}")
 
+        # Create the response message preserving the request id, but don't send it yet.
+        # This will be sent when response handler calls send()
+        self.response = OutboundMessageResponse(
+            request.thread_context_struct,
+            request.features,
+            InitializeExtensionResponse(self.extension.name, self.extension.implemented_interfaces),
+            request.version,
+            request.request_id,
+            request.is_handshake,
+            request.is_compress,
+        )
+
         # Sometime between tcp and transport handshakes and the eventual response,
         # the uniqueId gets added to the thread context.
         # request.thread_context_struct.request_headers["extension_unique_id"] = self.extension.name
-        self.extension.init_response_request_id = request.request_id
 
-        return self.send(
-            OutboundMessageRequest(
-                thread_context=request.thread_context_struct,
-                features=request.features,
-                message=RegisterRestActionsRequest(self.extension.name, self.extension.named_routes),
-                version=request.version,
-                action="internal:discovery/registerrestactions",
-                is_handshake=False,
-                is_compress=False,
-            )
+        # Now send our own initialization requests.
+
+        # Create the request, this gets us an auto-increment request id
+        register_request = OutboundMessageRequest(
+            thread_context=request.thread_context_struct,
+            features=request.features,
+            message=RegisterRestActionsRequest(self.extension.name, self.extension.named_routes),
+            version=request.version,
+            action="internal:discovery/registerrestactions",
+            is_handshake=False,
+            is_compress=False,
         )
+        # Register response handler to handle this request ID invoking this class's send()
+        register_response_handler = RegisterRestActionsResponseHandler(self)
+        self.response_handlers.register(register_request.request_id, register_response_handler)
+        # Now send the request
+        return register_response_handler.send(register_request)

--- a/src/opensearch_sdk_py/actions/internal/extension_rest_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/extension_rest_request_handler.py
@@ -30,21 +30,20 @@ class ExtensionRestRequestHandler(RequestHandler):
         route = f"{extension_rest_request.method.name} {extension_rest_request.path}"
         response = self.extension.handle(route, extension_rest_request)
 
-        return self.send(
-            OutboundMessageResponse(
-                request.thread_context_struct,
-                request.features,
-                RestExecuteOnExtensionResponse(
-                    status=response.status,
-                    content_type=response.content_type,
-                    content=response.content,
-                    headers=response.headers,
-                    consumed_params=response.consumed_params,
-                    content_consumed=response.content_consumed,
-                ),
-                request.version,
-                request.request_id,
-                request.is_handshake,
-                request.is_compress,
-            )
+        self.response = OutboundMessageResponse(
+            request.thread_context_struct,
+            request.features,
+            RestExecuteOnExtensionResponse(
+                status=response.status,
+                content_type=response.content_type,
+                content=response.content,
+                headers=response.headers,
+                consumed_params=response.consumed_params,
+                content_consumed=response.content_consumed,
+            ),
+            request.version,
+            request.request_id,
+            request.is_handshake,
+            request.is_compress,
         )
+        return self.send()

--- a/src/opensearch_sdk_py/actions/internal/register_rest_actions_response_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/register_rest_actions_response_handler.py
@@ -25,5 +25,7 @@ class RegisterRestActionsResponseHandler(ResponseHandler):
         ack_response = AcknowledgedResponse().read_from(input)
         logging.debug(f"< {ack_response}")
         if ack_response.status:
-            self.next_handler.send()
-        # TODO error handling
+            return self.next_handler.send()
+        else:
+            # TODO error handling
+            return None

--- a/src/opensearch_sdk_py/actions/internal/register_rest_actions_response_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/register_rest_actions_response_handler.py
@@ -1,0 +1,29 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import logging
+
+from opensearch_sdk_py.actions.request_response_handler import RequestResponseHandler
+from opensearch_sdk_py.actions.response_handler import ResponseHandler
+from opensearch_sdk_py.transport.acknowledged_response import AcknowledgedResponse
+from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class RegisterRestActionsResponseHandler(ResponseHandler):
+    def __init__(self, next_handler: RequestResponseHandler) -> None:
+        self.next_handler = next_handler
+
+    def handle(self, request: OutboundMessageRequest, input: StreamInput) -> StreamOutput:
+        ack_response = AcknowledgedResponse().read_from(input)
+        logging.debug(f"< {ack_response}")
+        if ack_response.status:
+            self.next_handler.send()
+        # TODO error handling

--- a/src/opensearch_sdk_py/actions/internal/request_error_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/request_error_handler.py
@@ -31,18 +31,17 @@ class RequestErrorHandler(RequestHandler):
         super().__init__("internal:error", extension)
 
     def handle(self, request: OutboundMessageRequest, input: StreamInput = None) -> StreamOutput:
-        return self.send(
-            OutboundMessageResponse(
-                request.thread_context_struct,
-                request.features,
-                RestExecuteOnExtensionResponse(
-                    status=self.status,
-                    content_type=self.content_type,
-                    content=self.content,
-                ),
-                request.version,
-                request.request_id,
-                request.is_handshake,
-                request.is_compress,
-            )
+        self.response = OutboundMessageResponse(
+            request.thread_context_struct,
+            request.features,
+            RestExecuteOnExtensionResponse(
+                status=self.status,
+                content_type=self.content_type,
+                content=self.content,
+            ),
+            request.version,
+            request.request_id,
+            request.is_handshake,
+            request.is_compress,
         )
+        return self.send()

--- a/src/opensearch_sdk_py/actions/internal/tcp_handshake_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/tcp_handshake_request_handler.py
@@ -26,14 +26,13 @@ class TcpHandshakeRequestHandler(RequestHandler):
     def handle(self, request: OutboundMessageRequest, input: StreamInput) -> StreamOutput:
         tcp_handshake = TransportHandshakerHandshakeRequest().read_from(input)
         logging.debug(f"< {tcp_handshake}")
-        return self.send(
-            OutboundMessageResponse(
-                request.thread_context_struct,
-                request.features,
-                TransportHandshakerHandshakeResponse(request.version),
-                request.version,
-                request.request_id,
-                request.is_handshake,
-                request.is_compress,
-            )
+        self.response = OutboundMessageResponse(
+            request.thread_context_struct,
+            request.features,
+            TransportHandshakerHandshakeResponse(request.version),
+            request.version,
+            request.request_id,
+            request.is_handshake,
+            request.is_compress,
         )
+        return self.send()

--- a/src/opensearch_sdk_py/actions/internal/transport_handshake_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/transport_handshake_request_handler.py
@@ -30,26 +30,25 @@ class TransportHandshakeRequestHandler(RequestHandler):
         transport_handshake = TransportServiceHandshakeRequest().read_from(input)
         logging.debug(f"< {transport_handshake}")
 
-        return self.send(
-            OutboundMessageResponse(
-                request.thread_context_struct,
-                request.features,
-                TransportServiceHandshakeResponse(
-                    DiscoveryNode(
-                        node_name="hello-world",
-                        node_id="hello-world",
-                        address=TransportAddress("127.0.0.1", 1234),
-                        roles={
-                            DiscoveryNodeRole.CLUSTER_MANAGER_ROLE,
-                            DiscoveryNodeRole.DATA_ROLE,
-                            DiscoveryNodeRole.INGEST_ROLE,
-                            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
-                        },
-                    )
-                ),
-                request.version,
-                request.request_id,
-                request.is_handshake,
-                request.is_compress,
-            )
+        self.response = OutboundMessageResponse(
+            request.thread_context_struct,
+            request.features,
+            TransportServiceHandshakeResponse(
+                DiscoveryNode(
+                    node_name="hello-world",
+                    node_id="hello-world",
+                    address=TransportAddress("127.0.0.1", 1234),
+                    roles={
+                        DiscoveryNodeRole.CLUSTER_MANAGER_ROLE,
+                        DiscoveryNodeRole.DATA_ROLE,
+                        DiscoveryNodeRole.INGEST_ROLE,
+                        DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
+                    },
+                )
+            ),
+            request.version,
+            request.request_id,
+            request.is_handshake,
+            request.is_compress,
         )
+        return self.send()

--- a/src/opensearch_sdk_py/actions/request_response_handler.py
+++ b/src/opensearch_sdk_py/actions/request_response_handler.py
@@ -1,0 +1,18 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+from abc import ABC, abstractmethod
+
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class RequestResponseHandler(ABC):
+    @abstractmethod
+    def send(self) -> StreamOutput:
+        pass  # pragma: no cover

--- a/src/opensearch_sdk_py/actions/response_handler.py
+++ b/src/opensearch_sdk_py/actions/response_handler.py
@@ -12,27 +12,21 @@ from abc import abstractmethod
 from typing import Optional
 
 from opensearch_sdk_py.actions.request_response_handler import RequestResponseHandler
-from opensearch_sdk_py.extension import Extension
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
 from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
 
 
-class RequestHandler(RequestResponseHandler):
-    def __init__(self, action: str, extension: Extension):
-        self.action = action
-        self.extension = extension
-        self.response: OutboundMessageResponse = None
-
+class ResponseHandler(RequestResponseHandler):
     @abstractmethod
-    def handle(self, request: OutboundMessageRequest, input: StreamInput = None) -> Optional[bytes]:
+    def handle(self, response: OutboundMessageResponse, input: StreamInput = None) -> Optional[bytes]:
         pass  # pragma: no cover
 
-    def send(self) -> StreamOutput:
+    def send(self, request: OutboundMessageRequest) -> StreamOutput:
         output = StreamOutput()
-        self.response.write_to(output)
+        request.write_to(output)
         raw_out = output.getvalue()
-        logging.info(f"> {self.response.__str__()}, size={len(raw_out)} byte(s)")
+        logging.info(f"> {request.__str__()}, size={len(raw_out)} byte(s)")
         logging.debug(f"> #{raw_out}")
         return output

--- a/src/opensearch_sdk_py/actions/response_handlers.py
+++ b/src/opensearch_sdk_py/actions/response_handlers.py
@@ -1,0 +1,28 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+from typing import Dict, Optional
+
+from opensearch_sdk_py.actions.response_handler import ResponseHandler
+from opensearch_sdk_py.extension import Extension
+from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
+from opensearch_sdk_py.transport.stream_input import StreamInput
+
+
+class ResponseHandlers(Dict[int, ResponseHandler]):
+    def __init__(self, extension: Extension) -> None:
+        self.extension = extension
+
+    def register(self, request_id: int, handler: ResponseHandler) -> None:
+        self[request_id] = handler
+
+    def handle(self, response: OutboundMessageResponse, input: StreamInput = None) -> Optional[bytes]:
+        handler = self[response.request_id]
+        del self[response.request_id]
+        return handler.handle(response, input) if handler else None

--- a/src/opensearch_sdk_py/server/async_extension_host.py
+++ b/src/opensearch_sdk_py/server/async_extension_host.py
@@ -16,10 +16,9 @@ from opensearch_sdk_py.actions.internal.extension_rest_request_handler import Ex
 from opensearch_sdk_py.actions.internal.tcp_handshake_request_handler import TcpHandshakeRequestHandler
 from opensearch_sdk_py.actions.internal.transport_handshake_request_handler import TransportHandshakeRequestHandler
 from opensearch_sdk_py.actions.request_handlers import RequestHandlers
+from opensearch_sdk_py.actions.response_handlers import ResponseHandlers
 from opensearch_sdk_py.extension import Extension
 from opensearch_sdk_py.server.async_host import AsyncHost
-from opensearch_sdk_py.transport.acknowledged_response import AcknowledgedResponse
-from opensearch_sdk_py.transport.initialize_extension_response import InitializeExtensionResponse
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
 from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.stream_input import StreamInput
@@ -28,17 +27,22 @@ from opensearch_sdk_py.transport.tcp_header import TcpHeader
 
 
 class AsyncExtensionHost(AsyncHost):
+    response_handlers: ResponseHandlers
     request_handlers: RequestHandlers
+
+    def __init_response_handlers(self) -> None:
+        self.response_handlers = ResponseHandlers(self.extension)
 
     def __init_request_handlers(self) -> None:
         self.request_handlers = RequestHandlers(self.extension)
-        self.request_handlers.register(DiscoveryExtensionsRequestHandler(self.extension))
+        self.request_handlers.register(DiscoveryExtensionsRequestHandler(self.extension, self.response_handlers))
         self.request_handlers.register(ExtensionRestRequestHandler(self.extension))
         self.request_handlers.register(TcpHandshakeRequestHandler(self.extension))
         self.request_handlers.register(TransportHandshakeRequestHandler(self.extension))
 
     def serve(self, extension: Extension) -> None:
         self.extension = extension
+        self.__init_response_handlers()
         self.__init_request_handlers()
 
     def on_input(self, input: StreamInput) -> StreamOutput:
@@ -54,24 +58,17 @@ class AsyncExtensionHost(AsyncHost):
                 error_handler = ActionNotFoundRequestErrorHandler(self.extension, request)
                 output = error_handler.handle(request, input)
         else:
-            response = OutboundMessageResponse().read_from(input, header)
-            # TODO: Error handling
+            response: OutboundMessageResponse = OutboundMessageResponse().read_from(input, header)
             if response.is_error:
+                # TODO: Error handling
                 output = None
                 logging.warning(f"< error {header}")
             else:
-                ack_response = AcknowledgedResponse().read_from(input)
-                logging.debug(f"< response {response}, {ack_response}")
-                output = StreamOutput()
-                response = OutboundMessageResponse(
-                    response.thread_context_struct,
-                    response.features,
-                    InitializeExtensionResponse(self.extension.name, self.extension.implemented_interfaces),
-                    response.version,
-                    self.extension.init_response_request_id,
-                    response.is_handshake,
-                    response.is_compress,
-                )
-                response.write_to(output)
-                logging.info(f"> {response}")
+                logging.info(f"< response {response}")
+                if response.request_id in self.response_handlers:
+                    output = self.response_handlers.handle(response, input)
+                else:
+                    # TODO: Error handling
+                    output = None
+                    logging.warning(f"< response id {response.request_id} not registered")
         return output

--- a/src/opensearch_sdk_py/server/async_extension_host.py
+++ b/src/opensearch_sdk_py/server/async_extension_host.py
@@ -67,7 +67,7 @@ class AsyncExtensionHost(AsyncHost):
                 logging.info(f"< response {response}")
                 if response.request_id in self.response_handlers:
                     output = self.response_handlers.handle(response, input)
-                else:
+                else:  # pragma: no cover
                     # TODO: Error handling
                     output = None
                     logging.warning(f"< response id {response.request_id} not registered")

--- a/tests/actions/internal/test_discovery_extensions_request_handler.py
+++ b/tests/actions/internal/test_discovery_extensions_request_handler.py
@@ -10,6 +10,7 @@
 import unittest
 
 from opensearch_sdk_py.actions.internal.discovery_extensions_request_handler import DiscoveryExtensionsRequestHandler
+from opensearch_sdk_py.actions.response_handlers import ResponseHandlers
 from opensearch_sdk_py.api.action_extension import ActionExtension
 from opensearch_sdk_py.extension import Extension
 from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
@@ -31,7 +32,8 @@ class TestDiscoveryExtensionsRequestHandler(unittest.TestCase):
 
     def setUp(self) -> None:
         self.extension = TestDiscoveryExtensionsRequestHandler.MyExtension()
-        self.handler = DiscoveryExtensionsRequestHandler(self.extension)
+        self.response_handlers = ResponseHandlers(self.extension)
+        self.handler = DiscoveryExtensionsRequestHandler(self.extension, self.response_handlers)
 
     def test_init(self) -> None:
         self.assertEqual(self.handler.action, "internal:discovery/extensions")
@@ -43,4 +45,4 @@ class TestDiscoveryExtensionsRequestHandler(unittest.TestCase):
         request = OutboundMessageRequest().read_from(input)
         output = self.handler.handle(request, input)
         self.assertIsInstance(output, StreamOutput)
-        self.assertEqual(self.extension.init_response_request_id, 10)
+        self.assertEqual(self.handler.response.request_id, 10)

--- a/tests/actions/internal/test_register_rest_actions_response_handler.py
+++ b/tests/actions/internal/test_register_rest_actions_response_handler.py
@@ -1,0 +1,41 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+from typing import Optional
+
+from opensearch_sdk_py.actions.internal.register_rest_actions_response_handler import RegisterRestActionsResponseHandler
+from opensearch_sdk_py.actions.response_handler import ResponseHandler
+from opensearch_sdk_py.transport.acknowledged_response import AcknowledgedResponse
+from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.version import Version
+
+
+class TestRegisterRestActionsResponseHandler(unittest.TestCase):
+    def test_register_rest_actions_response_handler(self) -> None:
+        input = StreamInput(bytes(OutboundMessageRequest(version=Version(2100099), message=AcknowledgedResponse(status=True))))
+        omr = OutboundMessageRequest().read_from(input)
+        next_handler = FakeResponseHandler()
+        output = RegisterRestActionsResponseHandler(next_handler).handle(omr, input)
+        self.assertEqual(output, b"test")
+
+        input = StreamInput(bytes(OutboundMessageRequest(version=Version(2100099), message=AcknowledgedResponse(status=False))))
+        omr = OutboundMessageRequest().read_from(input)
+        output = RegisterRestActionsResponseHandler(next_handler).handle(omr, input)
+        self.assertIsNone(output)
+
+
+class FakeResponseHandler(ResponseHandler):
+    def handle(self, request: OutboundMessageRequest, input: StreamInput = None) -> Optional[bytes]:
+        pass
+
+    def send(self) -> StreamOutput:
+        return b"test"

--- a/tests/actions/test_request_handlers.py
+++ b/tests/actions/test_request_handlers.py
@@ -29,12 +29,12 @@ class TestRequestHandlers(unittest.TestCase):
     def setUp(self) -> None:
         self.extension = TestRequestHandlers.MyExtension()
         self.request_handlers = RequestHandlers(self.extension)
-        self.request_handlers.register(DiscoveryExtensionsRequestHandler(self.extension))
+        self.request_handlers.register(DiscoveryExtensionsRequestHandler(self.extension, None))
         self.request_handlers.register(ExtensionRestRequestHandler(self.extension))
         self.request_handlers.register(TcpHandshakeRequestHandler(self.extension))
         self.request_handlers.register(TransportHandshakeRequestHandler(self.extension))
 
-    def test_registers_handler(self) -> None:
+    def test_register_handlers(self) -> None:
         self.assertEqual(len(self.request_handlers), 4)
         self.assertIsInstance(self.request_handlers["internal:tcp/handshake"], TcpHandshakeRequestHandler)
 

--- a/tests/actions/test_request_response_handler.py
+++ b/tests/actions/test_request_response_handler.py
@@ -1,0 +1,14 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+
+class TestRequestResponseHandler(unittest.TestCase):
+    pass

--- a/tests/actions/test_response_handler.py
+++ b/tests/actions/test_response_handler.py
@@ -1,0 +1,14 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+
+
+class TestResponseHandler(unittest.TestCase):
+    pass

--- a/tests/actions/test_response_handlers.py
+++ b/tests/actions/test_response_handlers.py
@@ -1,0 +1,57 @@
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+
+import unittest
+from typing import Optional
+
+from opensearch_sdk_py.actions.internal.register_rest_actions_response_handler import RegisterRestActionsResponseHandler
+from opensearch_sdk_py.actions.request_handler import RequestHandler
+from opensearch_sdk_py.actions.response_handlers import ResponseHandlers
+from opensearch_sdk_py.extension import Extension
+from opensearch_sdk_py.transport.acknowledged_response import AcknowledgedResponse
+from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
+from opensearch_sdk_py.transport.stream_input import StreamInput
+from opensearch_sdk_py.transport.stream_output import StreamOutput
+
+
+class TestResponseHandlers(unittest.TestCase):
+    class MyExtension(Extension):
+        def __init__(self) -> None:
+            super().__init__("test-extension")
+            self.test = ""
+
+    def setUp(self) -> None:
+        self.extension = TestResponseHandlers.MyExtension()
+        self.response_handlers = ResponseHandlers(self.extension)
+        next_handler = FakeRequestHandler(self.extension)
+        self.response_handlers.register(123, RegisterRestActionsResponseHandler(next_handler))
+
+    def test_register_handlers(self) -> None:
+        self.assertEqual(len(self.response_handlers), 1)
+        self.assertIsInstance(self.response_handlers[123], RegisterRestActionsResponseHandler)
+
+    def test_handle(self) -> None:
+        response = OutboundMessageResponse(request_id=123)
+        input = StreamInput(bytes(AcknowledgedResponse(status=True)))
+        output = self.response_handlers.handle(response, input)
+        self.assertEqual(output, None)
+        self.assertEqual(self.extension.test, "modified")
+
+
+class FakeRequestHandler(RequestHandler):
+    def __init__(self, extension: Extension) -> None:
+        super().__init__("test-extension", extension)
+
+    def handle(self, request: OutboundMessageRequest, input: StreamInput = None) -> Optional[bytes]:
+        return None
+
+    def send(self) -> StreamOutput:
+        self.extension.test = "modified"
+        return None

--- a/tests/actions/test_response_handlers.py
+++ b/tests/actions/test_response_handlers.py
@@ -41,6 +41,7 @@ class TestResponseHandlers(unittest.TestCase):
         response = OutboundMessageResponse(request_id=123)
         input = StreamInput(bytes(AcknowledgedResponse(status=True)))
         output = self.response_handlers.handle(response, input)
+        self.assertEqual(len(self.response_handlers), 0)
         self.assertEqual(output, None)
         self.assertEqual(self.extension.test, "modified")
 


### PR DESCRIPTION
### Description

Implements a response handling mechanism
 - Separated `handle` and `send` methods on the request handler, to permit sending a stored response at a later time
    - responses are assigned to a `response` variable on the superclass and `send()` now takes no arguments 
    - this removes the need to separately store/track the request_id used in the response
 - Implemented responses, where `send` and `handle` will happen in reverse order
    - This still assumes all request/resopnse actions happen in pairs, although allows any combination thereof
 - Before sending, we capture the outgoing request id and use it to register the appropriate response handler
    - this implementation can probably be improved by automating adding to the registry
 - When a response is received, the appropriate handler handles the response and gets removed from the registry
   - In the case of the rest registration response, handling means calling the delayed init response

Other misc. changes:
 - getting an event loop that wasn't created is [deprecated and will be removed in 3.11](https://stackoverflow.com/questions/73361664/asyncio-get-event-loop-deprecationwarning-there-is-no-current-event-loop).  Updated.
 - used sed to edit the protoc-generated files to achieve 100% code coverage on CI. 

### Issues Resolved

Fixes #31 (or at least most of the requests; separating the ability to "send" from requiring responses to go to the event loop would increase flexibility)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
