### PR TITLE
Remove protoc compiling from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       PYTHON_VERSION: '3.9'
-      PROTOBUF_SRC_DIR: ./src/opensearch_sdk_py/protobuf
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ env.PYTHON_VERSION }}
@@ -28,9 +27,6 @@ jobs:
       - name: Run Tests with Coverage
         run: |
           poetry install
-          protoc -I=$PROTOBUF_SRC_DIR --python_out=$PROTOBUF_SRC_DIR $PROTOBUF_SRC_DIR/*.proto
-          2to3 --no-diff -n -w $PROTOBUF_SRC_DIR
-          find $PROTOBUF_SRC_DIR -type f -name "*_pb2.py" | xargs sed -i.bak -E 's/(USE_C_DESCRIPTORS == False:)/\1  # pragma: no cover/g'
           poetry run coverage run --source=src -m pytest -v
           poetry run coverage xml
       - name: Upload Coverage Report

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -173,7 +173,7 @@ You can run a combination of these by installing [poetry-exec-plugin](https://gi
 
 ### Protobuf Class Generation
 
-Some Transport Requests use [Protobuf](https://protobuf.dev/) messages. These offer benefits including better reverse compatibility and easier cross-platform class generation. When using a new or updated proto definition (`.proto` file extension) you will need to compile it for use with python.
+Some Transport Requests use [Protobuf](https://protobuf.dev/) messages. These offer benefits including better reverse compatibility and easier cross-platform class generation. When using a new or updated proto definition (such as [these on OpenSearch](https://github.com/opensearch-project/OpenSearch/tree/main/server/src/main/proto/extensions)) you will need to compile it for use with python.
 1. Install [the Python compiler](https://github.com/protocolbuffers/protobuf/tree/main/python), usually with `pip install protobuf`.
 2. Define the source directory: `export PROTOBUF_SRC_DIR=./src/opensearch_sdk_py/protobuf`
 3. Compile: `protoc -I=$PROTOBUF_SRC_DIR --python_out=$PROTOBUF_SRC_DIR $PROTOBUF_SRC_DIR/*.proto`

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -12,6 +12,7 @@
   - [Code Linting](#code-linting)
   - [Type Checking](#type-checking)
   - [Code Coverage](#code-coverage)
+  - [Protobuf Class Generation](#protobuf-class-generation)
 - [License Headers](#license-headers)
   - [Visual Studio Code](#visual-studio-code)
 - [Transport Protocol](#transport-protocol)
@@ -169,6 +170,15 @@ TOTAL 1207 79 93%
 ```
 
 You can run a combination of these by installing [poetry-exec-plugin](https://github.com/keattang/poetry-exec-plugin) once and using the `poetry exec coverage` shortcut.
+
+### Protobuf Class Generation
+
+Some Transport Requests use [Protobuf](https://protobuf.dev/) messages. These offer benefits including better reverse compatibility and easier cross-platform class generation. When using a new or updated proto definition (`.proto` file extension) you will need to compile it for use with python.
+1. Install [the Python compiler](https://github.com/protocolbuffers/protobuf/tree/main/python), usually with `pip install protobuf`.
+2. Define the source directory: `export PROTOBUF_SRC_DIR=./src/opensearch_sdk_py/protobuf`
+3. Compile: `protoc -I=$PROTOBUF_SRC_DIR --python_out=$PROTOBUF_SRC_DIR $PROTOBUF_SRC_DIR/*.proto`
+4. The generated files need `from .` prepended to imports. Use `2to3 --no-diff -n -w $PROTOBUF_SRC_DIR` to do this
+5. Add `# pragma: no cover` to the conditional testing `_USE_C_DESCRIPTORS` to exclude that branch from coverage
 
 ## License Headers
 


### PR DESCRIPTION
### Description

Since protobuf autogenerated files change rarely (if ever) and require a few extra steps beyond compiling, it's better to not use them in the build. Instructions for the rare case of needing to recompile are added to the Developer Guide

### Issues Resolved

Fixes #23 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
