### PR TITLE
Renamed hello-world to hello-world-py.

### DIFF
--- a/samples/hello/README.md
+++ b/samples/hello/README.md
@@ -93,7 +93,7 @@ INFO:root:> prefix=b'ES', version=2.10.0.99, type=['response'], message=167 byte
 ### Call an Extension API
 
 ```bash
-curl -XGET "localhost:9200/_extensions/_hello-world/hello"
+curl -XGET "localhost:9200/_extensions/_hello-world-py/hello"
 Hello from Python! 👋
 ```
 

--- a/samples/hello/hello.json
+++ b/samples/hello/hello.json
@@ -1,6 +1,6 @@
 {
-    "name":"hello-world",
-    "uniqueId":"hello-world",
+    "name":"Hello World",
+    "uniqueId":"hello-world-py",
     "hostAddress":"127.0.0.1",
     "port":"1234",
     "version":"0.1.0",

--- a/samples/hello/hello_extension.py
+++ b/samples/hello/hello_extension.py
@@ -18,7 +18,7 @@ from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
 
 class HelloExtension(Extension, ActionExtension):
     def __init__(self) -> None:
-        Extension.__init__(self, "hello-world")
+        Extension.__init__(self, "hello-world-py")
         ActionExtension.__init__(self)
 
     @property

--- a/samples/hello/hello_rest_handler.py
+++ b/samples/hello/hello_rest_handler.py
@@ -22,7 +22,7 @@ class HelloRestHandler(ExtensionRestHandler):
     def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
         logging.debug(f"handling {rest_request}")
 
-        response_bytes = bytes("Hello from Python!", "utf-8") + b"\x20\xf0\x9f\x91\x8b"
+        response_bytes = bytes("Hello from Python! 👋\n", "utf-8")
         return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.TEXT_CONTENT_TYPE)
 
     @property

--- a/samples/hello/tests/test_hello.py
+++ b/samples/hello/tests/test_hello.py
@@ -52,7 +52,7 @@ def install_hello_extension() -> None:
 @pytest.mark.usefixtures("start_hello_extension", "install_hello_extension")
 class TestHello(unittest.TestCase):
     def test_hello_from_python(self) -> Any:
-        response = httpx.get("http://localhost:9200/_extensions/_hello-world/hello")
+        response = httpx.get("http://localhost:9200/_extensions/_hello-world-py/hello")
         logging.debug(response.text)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.text, "Hello from Python! 👋")
+        self.assertEqual(response.text, "Hello from Python! 👋\n")


### PR DESCRIPTION
### Description

Attempting to run both a Python and a Java extension on the same node, avoids naming conflict.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
