### PR TITLE
Handle named wildcards in REST routes

### DIFF
--- a/samples/hello/hello_rest_handler.py
+++ b/samples/hello/hello_rest_handler.py
@@ -21,10 +21,15 @@ from opensearch_sdk_py.rest.rest_status import RestStatus
 class HelloRestHandler(ExtensionRestHandler):
     def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
         logging.debug(f"handling {rest_request}")
-
-        response_bytes = bytes("Hello from Python! 👋\n", "utf-8")
-        return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.TEXT_CONTENT_TYPE)
+        consumed_params = list[str]()
+        if "name" in rest_request.params:
+            name = rest_request.params["name"]
+            consumed_params.append("name")
+            response_bytes = bytes(f"Hello {name}! 👋\n", "utf-8")
+        else:
+            response_bytes = bytes("Hello from Python! 👋\n", "utf-8")
+        return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.TEXT_CONTENT_TYPE, consumed_params=consumed_params)
 
     @property
     def routes(self) -> list[NamedRoute]:
-        return [NamedRoute(method=RestMethod.GET, path="/hello", unique_name="greeting")]
+        return [NamedRoute(method=RestMethod.GET, path="/hello", unique_name="greeting"), NamedRoute(method=RestMethod.GET, path="/hello/{name}", unique_name="personal_greeting")]

--- a/samples/hello/tests/test_hello.py
+++ b/samples/hello/tests/test_hello.py
@@ -56,3 +56,8 @@ class TestHello(unittest.TestCase):
         logging.debug(response.text)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, "Hello from Python! 👋\n")
+
+        response = httpx.get("http://localhost:9200/_extensions/_hello-world-py/hello/Tester")
+        logging.debug(response.text)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, "Hello Tester! 👋\n")

--- a/src/opensearch_sdk_py/rest/extension_rest_handlers.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handlers.py
@@ -7,6 +7,7 @@
 # compatible open source license.
 #
 
+import fnmatch
 import logging
 import re
 from typing import Dict
@@ -42,6 +43,8 @@ class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
         if route in self:
             return self[route].handle_request(request)
         # if no match try wildcard match
-        # TODO: iterate self.keys() and match wildcard *
-        # glob match would work but this is strings not files
-        # changing * to .* or .+ to use re.match seems awkward
+        for key in self.keys():
+            if fnmatch.fnmatch(route, key):
+                return self[key].handle_request(request)
+        # no match, we shouldn't get here if registration worked
+        raise Exception(f"Can not find a matching route for {route}.")

--- a/src/opensearch_sdk_py/rest/extension_rest_handlers.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_handlers.py
@@ -32,7 +32,6 @@ class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
             key = re.sub(r"\{(.+?)\}", "*", route.key)
             if key in self:
                 raise Exception(f"Can not register {route.key}, {key} is already registered.")
-
             # for matching the handler on the extension side only method and wildcard path matter
             self[key] = klass
             # but we have to send the full named route to OpenSearch
@@ -43,8 +42,8 @@ class ExtensionRestHandlers(Dict[str, ExtensionRestHandler]):
         if route in self:
             return self[route].handle_request(request)
         # if no match try wildcard match
-        for key in self.keys():
+        for key, handler in self.items():
             if fnmatch.fnmatch(route, key):
-                return self[key].handle_request(request)
+                return handler.handle_request(request)
         # no match, we shouldn't get here if registration worked
         raise Exception(f"Can not find a matching route for {route}.")

--- a/tests/rest/test_extension_rest_handlers.py
+++ b/tests/rest/test_extension_rest_handlers.py
@@ -19,7 +19,7 @@ from opensearch_sdk_py.rest.rest_status import RestStatus
 
 
 class TestExtensionRestHandlers(unittest.TestCase):
-    class FakeRestHandler(ExtensionRestHandler):
+    class FooBarRestHandler(ExtensionRestHandler):
         def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
             return ExtensionRestResponse(status=RestStatus.NOT_IMPLEMENTED)
 
@@ -27,29 +27,42 @@ class TestExtensionRestHandlers(unittest.TestCase):
         def routes(self) -> list[NamedRoute]:
             return [NamedRoute(RestMethod.GET, "/foo", "get_foo"), NamedRoute(RestMethod.GET, "/bar/{foo}", "get_bar")]
 
-    class DoubleFakeRestHandler(ExtensionRestHandler):
+    class BarFooRestHandler(ExtensionRestHandler):
         def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
-            return ExtensionRestResponse(status=RestStatus.NOT_IMPLEMENTED)
+            return ExtensionRestResponse(status=RestStatus.OK)
 
         @property
         def routes(self) -> list[NamedRoute]:
-            return [NamedRoute(RestMethod.GET, "/bar/{baz}", "get_baz")]
+            return [NamedRoute(RestMethod.GET, "/bar/{baz}", "get_baz"), NamedRoute(RestMethod.GET, "/foo/{bar}/baz/{qux}", "get_barqux")]
 
-    def test_registers_handler(self) -> None:
+    def test_register_handlers(self) -> None:
         handlers = ExtensionRestHandlers()
-        handlers.register(TestExtensionRestHandlers.FakeRestHandler())
+        handlers.register(TestExtensionRestHandlers.FooBarRestHandler())
         self.assertEqual(len(handlers), 2)
-        self.assertIsInstance(handlers["GET /foo"], TestExtensionRestHandlers.FakeRestHandler)
-        self.assertIsInstance(handlers["GET /bar/*"], TestExtensionRestHandlers.FakeRestHandler)
+        self.assertIsInstance(handlers["GET /foo"], TestExtensionRestHandlers.FooBarRestHandler)
+        self.assertIsInstance(handlers["GET /bar/*"], TestExtensionRestHandlers.FooBarRestHandler)
         self.assertListEqual(handlers.named_routes, ["GET /foo get_foo", "GET /bar/{foo} get_bar"])
-
         response = handlers.handle("GET /foo", ExtensionRestRequest())
         self.assertEqual(response.status, RestStatus.NOT_IMPLEMENTED)
-
         response = handlers.handle("GET /bar/anything", ExtensionRestRequest())
         self.assertEqual(response.status, RestStatus.NOT_IMPLEMENTED)
-
         error = r"Can not find a matching route for GET /baz."
         self.assertRaisesRegex(Exception, error, handlers.handle, "GET /baz", ExtensionRestRequest)
+
+    def test_register_wildcard_handlers(self) -> None:
+        handlers = ExtensionRestHandlers()
+        handlers.register(TestExtensionRestHandlers.BarFooRestHandler())
+        self.assertEqual(len(handlers), 2)
+        self.assertIsInstance(handlers["GET /bar/*"], TestExtensionRestHandlers.BarFooRestHandler)
+        self.assertIsInstance(handlers["GET /foo/*/baz/*"], TestExtensionRestHandlers.BarFooRestHandler)
+        self.assertListEqual(handlers.named_routes, ["GET /bar/{baz} get_baz", "GET /foo/{bar}/baz/{qux} get_barqux"])
+        response = handlers.handle("GET /bar/anything", ExtensionRestRequest())
+        self.assertEqual(response.status, RestStatus.OK)
+        response = handlers.handle("GET /foo/something/baz/anything", ExtensionRestRequest())
+        self.assertEqual(response.status, RestStatus.OK)
+
+    def test_register_conflicts(self) -> None:
+        handlers = ExtensionRestHandlers()
+        handlers.register(TestExtensionRestHandlers.FooBarRestHandler())
         error = r"Can not register GET /bar/{baz}, GET /bar/\* is already registered."
-        self.assertRaisesRegex(Exception, error, handlers.register, TestExtensionRestHandlers.DoubleFakeRestHandler())
+        self.assertRaisesRegex(Exception, error, handlers.register, TestExtensionRestHandlers.BarFooRestHandler())


### PR DESCRIPTION
### Description

1. Prevents registering multiple REST routes with the same wildcards which would throw an exception on OpenSearch RestController
2. Match incoming rest requests to the wildcard key for the dictionary

### Issues Resolved

Fixes #35 
Fixes #45

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
