### PR TITLE
Track consumed parameters and content

### DIFF
--- a/samples/crud/CREATE_CRUD_EXTENSION.md
+++ b/samples/crud/CREATE_CRUD_EXTENSION.md
@@ -88,13 +88,13 @@ class CRUDRestHandler(ExtensionRestHandler):
                 refresh=True
             ) 
             response_bytes = bytes(json.dumps(response).encode("utf-8"))
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
         
         elif request.method == RestMethod.GET:
             # Search for documents
-            index_name = 'test-index'
-            q = request.params.get('q')
-            
+            index_name = "test-index"
+            q = request.param("q")
+
             logging.info(f"inside get {q}")
 
             query = {
@@ -111,36 +111,31 @@ class CRUDRestHandler(ExtensionRestHandler):
                 index=index_name
             )
             response_bytes = bytes(json.dumps(response).encode("utf-8"))
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=['q'])
-        
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
+
         elif request.method == RestMethod.PUT:
             # Update a document
-            index_name = 'test-index'
-            id = request.params.get('id')
+            index_name = "test-index"            
+            id = request.param("id")
             document = request.content
-            response = self.client.index(
-                index=index_name,
-                body=document,
-                id=id,
-                refresh=True
-            )
+            response = self.client.index(index=index_name, body=document, id=id, refresh=True)
             response_bytes = bytes(json.dumps(response), "utf-8")
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=['id'])
-        
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
+
         elif request.method == RestMethod.DELETE:
             # Delete a document
-            index_name = 'test-index'
-            id = request.params.get('id')
+            index_name = "test-index"
+            id = request.param("id")
             response = self.client.delete(
                 index=index_name,
                 id=id
             )
             response_bytes = bytes(json.dumps(response), "utf-8")
             logging.info(f"response: {response}")
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=['id'])
-        
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
+
         else:
-            return ExtensionRestResponse(RestStatus.METHOD_NOT_ALLOWED, bytes("Not found", "utf-8"), ExtensionRestResponse.TEXT_CONTENT_TYPE)
+            return ExtensionRestResponse(RestStatus.NOT_FOUND, bytes("Not found", "utf-8"), ExtensionRestResponse.TEXT_CONTENT_TYPE)
         
     @property
     def routes(self) -> list[NamedRoute]:
@@ -174,7 +169,7 @@ The CRUD extension will handle the following methods:
 - GET /crud: Search for documents
     ```
     index_name = 'test-index'
-    q = request.params.get('q')
+    q = request.param("q")
     
     logging.info(f"inside get {q}")
 
@@ -192,14 +187,14 @@ The CRUD extension will handle the following methods:
         index=index_name
     )
     response_bytes = bytes(json.dumps(response).encode("utf-8"))
-    return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=['q'])
+    return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["q"])
     ```
-    get method takes a query parameter `q` and searches for documents in the index with the given query. We have mentioned `consumed_params=['q']` to indicate that the extension has consumed the `q` parameter.
+    get method takes a query parameter `q` and searches for documents in the index with the given query. We have mentioned `consumed_params=["q"]` to indicate that the extension has consumed the `q` parameter.
 
 - PUT /crud: Update a document
     ```
     index_name = 'test-index'
-    id = request.params.get('id')
+    id = request.param("id")
     document = request.content
     response = self.client.index(
         index=index_name,
@@ -208,30 +203,30 @@ The CRUD extension will handle the following methods:
         refresh=True
     )
     response_bytes = bytes(json.dumps(response), "utf-8")
-    return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=['id'])
+    return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["id"])
     ```
-    put method takes an id parameter and updates the document with the given id in the index. The document is passed as the request content. We have mentioned `consumed_params=['id']` to indicate that the extension has consumed the `id` parameter.
+    put method takes an id parameter and updates the document with the given id in the index. The document is passed as the request content. We have mentioned `consumed_params=["id"]` to indicate that the extension has consumed the `id` parameter.
 
 - DELETE /crud: Delete a document
     ```
     index_name = 'test-index'
-    id = request.params.get('id')
+    id = request.param("id")
     response = self.client.delete(
         index=index_name,
         id=id
     )
     response_bytes = bytes(json.dumps(response), "utf-8")
     logging.info(f"response: {response}")
-    return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=['id'])
+    return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["id"])
     ```
-    delete method takes an id parameter and deletes the document with the given id from the index. We have mentioned `consumed_params=['id']` to indicate that the extension has consumed the `id` parameter.
+    delete method takes an id parameter and deletes the document with the given id from the index. We have mentioned `consumed_params=["id"]` to indicate that the extension has consumed the `id` parameter.
 
 ## Register the Extension
 
 Register the extension with OpenSearch by sending a POST request to the _extension/initialize endpoint. The request body should contain the extension name and the path to the extension.json file.
 
 ```bash
-curl -XPOST "localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data @samples/crud_extension/crud.json
+curl -XPOST "localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data @samples/crud/crud.json
 
 {"success":"A request to initialize an extension has been sent."}
 ```

--- a/samples/crud/crud_handler.py
+++ b/samples/crud/crud_handler.py
@@ -34,41 +34,41 @@ class CRUDRestHandler(ExtensionRestHandler):
         if request.method == RestMethod.POST:
             # Create a document
             index_name = "test-index"
-            document = request.content
+            document = request.content()
             response = self.client.index(index=index_name, body=document, refresh=True)
             response_bytes = bytes(json.dumps(response).encode("utf-8"))
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
 
         elif request.method == RestMethod.GET:
             # Search for documents
             index_name = "test-index"
-            q = request.params.get("q")
+            q = request.param("q")
 
             query = {"size": 5, "query": {"multi_match": {"query": q, "fields": ["title^2", "director"]}}}
             response = self.client.search(body=query, index=index_name)
             response_bytes = bytes(json.dumps(response).encode("utf-8"))
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["q"])
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
 
         elif request.method == RestMethod.PUT:
             # Update a document
             index_name = "test-index"
-            id = request.params.get("id")
-            document = request.content
+            id = request.param("id")
+            document = request.content()
             response = self.client.index(index=index_name, body=document, id=id, refresh=True)
             response_bytes = bytes(json.dumps(response), "utf-8")
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["id"])
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
 
         elif request.method == RestMethod.DELETE:
             # Delete a document
             index_name = "test-index"
-            id = request.params.get("id")
+            id = request.param("id")
             response = self.client.delete(index=index_name, id=id)
             response_bytes = bytes(json.dumps(response), "utf-8")
             logging.info(f"response: {response}")
-            return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE, consumed_params=["id"])
+            return ExtensionRestResponse(request, RestStatus.OK, response_bytes, ExtensionRestResponse.JSON_CONTENT_TYPE)
 
         else:
-            return ExtensionRestResponse(RestStatus.METHOD_NOT_ALLOWED, bytes("Not found", "utf-8"), ExtensionRestResponse.TEXT_CONTENT_TYPE)
+            return ExtensionRestResponse(RestStatus.NOT_FOUND, bytes("Not found", "utf-8"), ExtensionRestResponse.TEXT_CONTENT_TYPE)
 
     @property
     def routes(self) -> list[NamedRoute]:

--- a/samples/hello/hello_rest_handler.py
+++ b/samples/hello/hello_rest_handler.py
@@ -21,14 +21,12 @@ from opensearch_sdk_py.rest.rest_status import RestStatus
 class HelloRestHandler(ExtensionRestHandler):
     def handle_request(self, rest_request: ExtensionRestRequest) -> ExtensionRestResponse:
         logging.debug(f"handling {rest_request}")
-        consumed_params = list[str]()
-        if "name" in rest_request.params:
-            name = rest_request.params["name"]
-            consumed_params.append("name")
+        name = rest_request.param("name")
+        if name is not None:
             response_bytes = bytes(f"Hello {name}! 👋\n", "utf-8")
         else:
             response_bytes = bytes("Hello from Python! 👋\n", "utf-8")
-        return ExtensionRestResponse(RestStatus.OK, response_bytes, ExtensionRestResponse.TEXT_CONTENT_TYPE, consumed_params=consumed_params)
+        return ExtensionRestResponse(rest_request, RestStatus.OK, response_bytes, ExtensionRestResponse.TEXT_CONTENT_TYPE)
 
     @property
     def routes(self) -> list[NamedRoute]:

--- a/src/opensearch_sdk_py/rest/extension_rest_response.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_response.py
@@ -9,6 +9,7 @@
 
 # https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/extensions/rest/ExtensionRestResponse.java
 
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
 from opensearch_sdk_py.rest.rest_status import RestStatus
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
@@ -22,20 +23,23 @@ class ExtensionRestResponse(TransportResponse):
 
     def __init__(
         self,
+        request: ExtensionRestRequest = None,
         status: RestStatus = None,
         content: bytes = b"",
         content_type: str = TEXT_CONTENT_TYPE,
         headers: dict[str, list[str]] = dict(),
-        consumed_params: list[str] = [],
-        content_consumed: bool = False,
     ) -> None:
         super().__init__()
         self.status = status
         self.content = content
         self.content_type = content_type
         self.headers = headers
-        self.consumed_params = consumed_params
-        self.content_consumed = content_consumed
+        if request is not None:
+            self.consumed_params = request.consumed_params
+            self.content_consumed = request.content_consumed
+        else:
+            self.consumed_params = []
+            self.content_consumed = False
 
     def read_from(self, input: StreamInput) -> "ExtensionRestResponse":
         super().read_from(input)

--- a/src/opensearch_sdk_py/rest/extension_rest_response.py
+++ b/src/opensearch_sdk_py/rest/extension_rest_response.py
@@ -34,12 +34,11 @@ class ExtensionRestResponse(TransportResponse):
         self.content = content
         self.content_type = content_type
         self.headers = headers
+        self.consumed_params: set[str] = set()
+        self.content_consumed = False
         if request is not None:
             self.consumed_params = request.consumed_params
             self.content_consumed = request.content_consumed
-        else:
-            self.consumed_params = []
-            self.content_consumed = False
 
     def read_from(self, input: StreamInput) -> "ExtensionRestResponse":
         super().read_from(input)
@@ -47,7 +46,7 @@ class ExtensionRestResponse(TransportResponse):
         self.content = input.read_bytes(input.read_array_size())
         self.content_type = input.read_string()
         self.headers = input.read_string_to_string_array_dict()
-        self.consumed_params = input.read_string_array()
+        self.consumed_params = set(input.read_string_array())
         self.content_consumed = input.read_boolean()
         return self
 
@@ -58,6 +57,6 @@ class ExtensionRestResponse(TransportResponse):
         output.write(self.content)
         output.write_string(self.content_type)
         output.write_string_to_string_array_dict(self.headers)
-        output.write_string_array(self.consumed_params)
+        output.write_string_array(sorted(self.consumed_params))
         output.write_boolean(self.content_consumed)
         return self

--- a/tests/rest/test_extension_rest_request.py
+++ b/tests/rest/test_extension_rest_request.py
@@ -66,8 +66,7 @@ class TestExtensionRestRequest(unittest.TestCase):
         self.assertFalse(err.has_param("bar"))
         self.assertSetEqual(err.consumed_params, {"foo"})
         self.assertIsNone(err.param("bar"))
-        self.assertTrue("foo" in err.consumed_params)
-        self.assertTrue("bar" in err.consumed_params)
+        self.assertSetEqual(err.consumed_params, {"foo", "bar"})
 
         self.assertTrue(err.has_content())
         self.assertFalse(err.content_consumed)

--- a/tests/rest/test_extension_rest_request.py
+++ b/tests/rest/test_extension_rest_request.py
@@ -35,7 +35,7 @@ class TestExtensionRestRequest(unittest.TestCase):
         self.assertDictEqual(err.params, {"foo": "bar"})
         self.assertDictEqual(err.headers, {"foo": ["bar", "baz"]})
         self.assertEqual(err.media_type, "application/json; charset=utf-8")
-        self.assertEqual(err.content, bytes("{}", "ascii"))
+        self.assertEqual(err.content(), bytes("{}", "ascii"))
         self.assertEqual(err.principal_identifier_token, "token")
         self.assertEqual(err.http_version, HttpVersion.HTTP_1_1)
         self.assertIn("method=RestMethod.GET, uri=/hello?v, path=/hello", str(err))
@@ -51,6 +51,27 @@ class TestExtensionRestRequest(unittest.TestCase):
         self.assertDictEqual(err.params, {"foo": "bar"})
         self.assertDictEqual(err.headers, {"foo": ["bar", "baz"]})
         self.assertEqual(err.media_type, "application/json; charset=utf-8")
-        self.assertEqual(err.content, bytes("{}", "ascii"))
+        self.assertEqual(err.content(), bytes("{}", "ascii"))
         self.assertEqual(err.principal_identifier_token, "token")
         self.assertEqual(err.http_version, HttpVersion.HTTP_1_1)
+
+    def test_consuming(self) -> None:
+        err = ExtensionRestRequest(
+            params={"foo": "bar"},
+            content=bytes("{}", "ascii"),
+        )
+        self.assertTrue(err.has_param("foo"))
+        self.assertSetEqual(err.consumed_params, set())
+        self.assertEqual(err.param("foo"), "bar")
+        self.assertFalse(err.has_param("bar"))
+        self.assertSetEqual(err.consumed_params, {"foo"})
+        self.assertIsNone(err.param("bar"))
+        self.assertTrue("foo" in err.consumed_params)
+        self.assertTrue("bar" in err.consumed_params)
+
+        self.assertTrue(err.has_content())
+        self.assertFalse(err.content_consumed)
+        err.content(False)
+        self.assertFalse(err.content_consumed)
+        err.content()
+        self.assertTrue(err.content_consumed)

--- a/tests/rest/test_extension_rest_response.py
+++ b/tests/rest/test_extension_rest_response.py
@@ -9,6 +9,7 @@
 
 import unittest
 
+from opensearch_sdk_py.rest.extension_rest_request import ExtensionRestRequest
 from opensearch_sdk_py.rest.extension_rest_response import ExtensionRestResponse
 from opensearch_sdk_py.rest.rest_status import RestStatus
 from opensearch_sdk_py.transport.stream_input import StreamInput
@@ -24,12 +25,16 @@ class TestExtensionRestResponse(unittest.TestCase):
         self.assertListEqual(err.consumed_params, [])
         self.assertFalse(err.content_consumed)
 
-        err = ExtensionRestResponse(status=RestStatus.OK, content=b"test", content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, headers={"foo": ["bar", "baz"]}, consumed_params=["foo", "bar"], content_consumed=True)
+        req = ExtensionRestRequest()
+        req.param("foo")
+        req.param("bar")
+        req.content()
+        err = ExtensionRestResponse(request=req, status=RestStatus.OK, content=b"test", content_type=ExtensionRestResponse.JSON_CONTENT_TYPE, headers={"foo": ["bar", "baz"]})
         self.assertEqual(err.status, RestStatus.OK)
         self.assertEqual(err.content, b"test")
         self.assertEqual(err.content_type, ExtensionRestResponse.JSON_CONTENT_TYPE)
         self.assertDictEqual(err.headers, {"foo": ["bar", "baz"]})
-        self.assertListEqual(err.consumed_params, ["foo", "bar"])
+        self.assertSetEqual(err.consumed_params, {"foo", "bar"})
         self.assertTrue(err.content_consumed)
 
         output = StreamOutput()

--- a/tests/rest/test_extension_rest_response.py
+++ b/tests/rest/test_extension_rest_response.py
@@ -22,7 +22,7 @@ class TestExtensionRestResponse(unittest.TestCase):
         self.assertEqual(err.content, b"")
         self.assertEqual(err.content_type, ExtensionRestResponse.TEXT_CONTENT_TYPE)
         self.assertDictEqual(err.headers, {})
-        self.assertListEqual(err.consumed_params, [])
+        self.assertSetEqual(err.consumed_params, set())
         self.assertFalse(err.content_consumed)
 
         req = ExtensionRestRequest()
@@ -46,5 +46,5 @@ class TestExtensionRestResponse(unittest.TestCase):
         self.assertEqual(err.content, b"test")
         self.assertEqual(err.content_type, ExtensionRestResponse.JSON_CONTENT_TYPE)
         self.assertDictEqual(err.headers, {"foo": ["bar", "baz"]})
-        self.assertListEqual(err.consumed_params, ["foo", "bar"])
+        self.assertSetEqual(err.consumed_params, {"foo", "bar"})
         self.assertTrue(err.content_consumed)


### PR DESCRIPTION
### Description

Tracks consumed parameters and content.

TODO:
 - [x] add an `ExtensionRestRequest` parameter to the `ExtensionRestResponse` so these properties can be automatically handled
 - [x] update CRUD sample in #71 with this new style
 - [x] update hello world sample in #75 with this new style

### Issues Resolved

Fixes #49 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
