### PR TITLE
Refactor key checks into request and response handlers

### DIFF
--- a/src/opensearch_sdk_py/actions/request_handlers.py
+++ b/src/opensearch_sdk_py/actions/request_handlers.py
@@ -23,5 +23,7 @@ class RequestHandlers(Dict[str, RequestHandler]):
         self[handler.action] = handler
 
     def handle(self, request: OutboundMessageRequest, input: StreamInput = None) -> Optional[bytes]:
-        handler = self[request.action]
-        return handler.handle(request, input) if handler else None
+        if request.action in self:
+            handler = self[request.action]
+            return handler.handle(request, input) if handler else None
+        return None

--- a/src/opensearch_sdk_py/actions/response_handlers.py
+++ b/src/opensearch_sdk_py/actions/response_handlers.py
@@ -23,6 +23,8 @@ class ResponseHandlers(Dict[int, ResponseHandler]):
         self[request_id] = handler
 
     def handle(self, response: OutboundMessageResponse, input: StreamInput = None) -> Optional[bytes]:
-        handler = self[response.request_id]
-        del self[response.request_id]
-        return handler.handle(response, input) if handler else None
+        if response.request_id in self:
+            handler = self[response.request_id]
+            del self[response.request_id]
+            return handler.handle(response, input) if handler else None
+        return None

--- a/tests/actions/test_response_handlers.py
+++ b/tests/actions/test_response_handlers.py
@@ -45,6 +45,12 @@ class TestResponseHandlers(unittest.TestCase):
         self.assertEqual(output, None)
         self.assertEqual(self.extension.test, "modified")
 
+    def test_handle_unregistered(self) -> None:
+        response = OutboundMessageResponse(request_id=1234)
+        input = StreamInput(bytes(AcknowledgedResponse(status=True)))
+        output = self.response_handlers.handle(response, input)
+        self.assertIsNone(output)
+
 
 class FakeRequestHandler(RequestHandler):
     def __init__(self, extension: Extension) -> None:


### PR DESCRIPTION
### Description

Moves the "if key exists" checks from the async host into the handler, using a None return for any further logic.

### Issues Resolved

Fixes #56 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
