### PR TITLE
Don't run GHA on repo branches generated by automation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,11 @@
 name: integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'whitesource-remediate/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,12 @@
 ---
 name: lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'whitesource-remediate/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 ---
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'whitesource-remediate/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   tests:


### PR DESCRIPTION
### Description

Stops running GHA on pushes to `whitesource-remediate` branch (Mend Remediate dependency management).  The GHA will run on the pull request when it's generated.

### Issues Resolved

Fixes #79

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
