### PR TITLE
Properly handle node version and min compatibility versions

### DIFF
--- a/src/opensearch_sdk_py/actions/internal/discovery_extensions_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/discovery_extensions_request_handler.py
@@ -23,6 +23,7 @@ from opensearch_sdk_py.transport.register_rest_actions_request import RegisterRe
 from opensearch_sdk_py.transport.request_type import RequestType
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.version import Version
 
 
 class DiscoveryExtensionsRequestHandler(RequestHandler):
@@ -43,7 +44,7 @@ class DiscoveryExtensionsRequestHandler(RequestHandler):
             request.thread_context_struct,
             request.features,
             InitializeExtensionResponse(self.extension.name, self.extension.implemented_interfaces),
-            request.version,
+            Version(Version.MIN_COMPAT),
             request.request_id,
             request.is_handshake,
             request.is_compress,
@@ -54,7 +55,7 @@ class DiscoveryExtensionsRequestHandler(RequestHandler):
             thread_context=request.thread_context_struct,
             features=request.features,
             message=ExtensionTransportRequest(RequestType.REQUEST_EXTENSION_ENVIRONMENT_SETTINGS),
-            version=request.version,
+            version=Version(Version.MIN_COMPAT),
             action="internal:discovery/enviornmentsettings",
         )
         settings_response_handler = EnvironmentSettingsResponseHandler(self)
@@ -65,7 +66,7 @@ class DiscoveryExtensionsRequestHandler(RequestHandler):
             thread_context=request.thread_context_struct,
             features=request.features,
             message=RegisterRestActionsRequest(self.extension.name, self.extension.named_routes),
-            version=request.version,
+            version=Version(Version.MIN_COMPAT),
             action="internal:discovery/registerrestactions",
         )
         register_response_handler = RegisterRestActionsResponseHandler(settings_response_handler, settings_request)

--- a/src/opensearch_sdk_py/actions/internal/extension_rest_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/extension_rest_request_handler.py
@@ -17,6 +17,7 @@ from opensearch_sdk_py.transport.outbound_message_request import OutboundMessage
 from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.version import Version
 
 
 class ExtensionRestRequestHandler(RequestHandler):
@@ -41,7 +42,7 @@ class ExtensionRestRequestHandler(RequestHandler):
                 consumed_params=response.consumed_params,
                 content_consumed=response.content_consumed,
             ),
-            request.version,
+            Version(Version.MIN_COMPAT),
             request.request_id,
             request.is_handshake,
             request.is_compress,

--- a/src/opensearch_sdk_py/actions/internal/request_error_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/request_error_handler.py
@@ -15,6 +15,7 @@ from opensearch_sdk_py.transport.outbound_message_request import OutboundMessage
 from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.version import Version
 
 
 class RequestErrorHandler(RequestHandler):
@@ -39,7 +40,7 @@ class RequestErrorHandler(RequestHandler):
                 content_type=self.content_type,
                 content=self.content,
             ),
-            request.version,
+            Version(Version.MIN_COMPAT),
             request.request_id,
             request.is_handshake,
             request.is_compress,

--- a/src/opensearch_sdk_py/actions/internal/tcp_handshake_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/tcp_handshake_request_handler.py
@@ -17,6 +17,7 @@ from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
 from opensearch_sdk_py.transport.transport_handshaker_handshake_request import TransportHandshakerHandshakeRequest
 from opensearch_sdk_py.transport.transport_handshaker_handshake_response import TransportHandshakerHandshakeResponse
+from opensearch_sdk_py.transport.version import Version
 
 
 class TcpHandshakeRequestHandler(RequestHandler):
@@ -29,8 +30,8 @@ class TcpHandshakeRequestHandler(RequestHandler):
         self.response = OutboundMessageResponse(
             request.thread_context_struct,
             request.features,
-            TransportHandshakerHandshakeResponse(request.version),
-            request.version,
+            TransportHandshakerHandshakeResponse(Version(Version.CURRENT)),
+            Version(Version.MIN_COMPAT),
             request.request_id,
             request.is_handshake,
             request.is_compress,

--- a/src/opensearch_sdk_py/actions/internal/transport_handshake_request_handler.py
+++ b/src/opensearch_sdk_py/actions/internal/transport_handshake_request_handler.py
@@ -20,6 +20,7 @@ from opensearch_sdk_py.transport.stream_output import StreamOutput
 from opensearch_sdk_py.transport.transport_address import TransportAddress
 from opensearch_sdk_py.transport.transport_service_handshake_request import TransportServiceHandshakeRequest
 from opensearch_sdk_py.transport.transport_service_handshake_response import TransportServiceHandshakeResponse
+from opensearch_sdk_py.transport.version import Version
 
 
 class TransportHandshakeRequestHandler(RequestHandler):
@@ -46,7 +47,7 @@ class TransportHandshakeRequestHandler(RequestHandler):
                     },
                 )
             ),
-            request.version,
+            Version(Version.MIN_COMPAT),
             request.request_id,
             request.is_handshake,
             request.is_compress,

--- a/src/opensearch_sdk_py/transport/version.py
+++ b/src/opensearch_sdk_py/transport/version.py
@@ -9,6 +9,7 @@
 class Version:
     MASK = 0x08000000
     CURRENT = 3000099
+    MIN_COMPAT = 7099999
     CURRENT_ID = CURRENT ^ MASK
 
     def __init__(self, id: int = 0) -> None:

--- a/tests/actions/internal/test_action_not_found_request_error_handler.py
+++ b/tests/actions/internal/test_action_not_found_request_error_handler.py
@@ -41,3 +41,4 @@ class TestActionNotFoundRequestHandler(unittest.TestCase):
         message = OutboundMessageResponse().read_from(StreamInput(response.getvalue()))
         self.assertEqual(message.request_id, self.request.request_id)
         self.assertEqual(message.message_bytes, None)
+        self.assertEqual(message.version.id ^ Version.MASK, Version.MIN_COMPAT)

--- a/tests/actions/internal/test_discovery_extensions_request_handler.py
+++ b/tests/actions/internal/test_discovery_extensions_request_handler.py
@@ -15,8 +15,10 @@ from opensearch_sdk_py.api.action_extension import ActionExtension
 from opensearch_sdk_py.extension import Extension
 from opensearch_sdk_py.rest.extension_rest_handler import ExtensionRestHandler
 from opensearch_sdk_py.transport.outbound_message_request import OutboundMessageRequest
+from opensearch_sdk_py.transport.outbound_message_response import OutboundMessageResponse
 from opensearch_sdk_py.transport.stream_input import StreamInput
 from opensearch_sdk_py.transport.stream_output import StreamOutput
+from opensearch_sdk_py.transport.version import Version
 from tests.transport.data.netty_trace_data import NettyTraceData
 
 
@@ -46,3 +48,5 @@ class TestDiscoveryExtensionsRequestHandler(unittest.TestCase):
         output = self.handler.handle(request, input)
         self.assertIsInstance(output, StreamOutput)
         self.assertEqual(self.handler.response.request_id, 10)
+        message = OutboundMessageResponse().read_from(StreamInput(output.getvalue()))
+        self.assertEqual(message.version.id ^ Version.MASK, Version.MIN_COMPAT)

--- a/tests/actions/internal/test_extensions_rest_request_handler.py
+++ b/tests/actions/internal/test_extensions_rest_request_handler.py
@@ -64,6 +64,7 @@ class TestExtensionsRestRequestHandler(unittest.TestCase):
         input = StreamInput(output.getvalue())
         response = OutboundMessageResponse()
         response.read_from(input)
+        self.assertEqual(response.version.id ^ Version.MASK, Version.MIN_COMPAT)
         message = RestExecuteOnExtensionResponse()
         message.read_from(input)
         self.assertEqual(RestStatus.OK, message.status)

--- a/tests/actions/internal/test_request_error_handler.py
+++ b/tests/actions/internal/test_request_error_handler.py
@@ -50,6 +50,7 @@ class TestRequestErrorHandler(unittest.TestCase):
         input = StreamInput(output.getvalue())
         response = OutboundMessageResponse()
         response.read_from(input)
+        self.assertEqual(response.version.id ^ Version.MASK, Version.MIN_COMPAT)
         message = RestExecuteOnExtensionResponse()
         message.read_from(input)
         self.assertEqual(RestStatus.NOT_FOUND, message.status)

--- a/tests/actions/internal/test_tcp_handshake_request_handler.py
+++ b/tests/actions/internal/test_tcp_handshake_request_handler.py
@@ -44,6 +44,7 @@ class TestTcpHandshakeRequestHandler(unittest.TestCase):
         input = StreamInput(output.getvalue())
         response = OutboundMessageResponse()
         response.read_from(input)
+        self.assertEqual(response.version.id ^ Version.MASK, Version.MIN_COMPAT)
         message = TransportHandshakerHandshakeResponse()
         message.read_from(input)
         self.assertEqual(message.version.id, Version.CURRENT_ID)

--- a/tests/actions/internal/test_transport_handshake_request_handler.py
+++ b/tests/actions/internal/test_transport_handshake_request_handler.py
@@ -45,6 +45,7 @@ class TestTransportHandshakeRequestHandler(unittest.TestCase):
         input = StreamInput(output.getvalue())
         response = OutboundMessageResponse()
         response.read_from(input)
+        self.assertEqual(response.version.id ^ Version.MASK, Version.MIN_COMPAT)
         message = TransportServiceHandshakeResponse()
         message.read_from(input)
         self.assertIsInstance(message.discovery_node, DiscoveryNode)

--- a/tests/server/test_async_extension_host.py
+++ b/tests/server/test_async_extension_host.py
@@ -141,6 +141,7 @@ class TestAsyncExtensionHost(unittest.TestCase):
         assert responses[1] is not None
         reply: TestAsyncExtensionHost.Response = responses[1]
         self.assertEqual(reply.response.thread_context_struct.request_headers, {"_system_index_access_allowed": "false"})
+        self.assertEqual(reply.response.version.id ^ Version.MASK, Version.MIN_COMPAT)
         extension_request = ExtensionTransportRequest(RequestType.GET_SETTINGS).read_from(reply.remaining_input)
         self.assertEqual(extension_request.er.requestType, RequestType.REQUEST_EXTENSION_ENVIRONMENT_SETTINGS.value)
 

--- a/tests/transport/data/netty_trace_data.py
+++ b/tests/transport/data/netty_trace_data.py
@@ -10,7 +10,6 @@
 import re
 from typing import Optional, Union
 
-
 #
 # Read netty-formatted log data.
 #
@@ -22,6 +21,14 @@ from typing import Optional, Union
 # |00000020| 6e 61 6c 3a 74 63 70 2f 68 61 6e 64 73 68 61 6b |nal:tcp/handshak|
 # |00000030| 65 00 04 a3 8e b7 41                            |e.....A         |
 # +--------+-------------------------------------------------+----------------+
+#
+# Handshake version notes: 0x200b83 at byte 15 is 2100099 (2.10.0 was last minor release for this log).
+# This is the minimum compatible version. For version 3.x is last 2.x minor version.
+# For version 2.x is 7100099, see computeMinCompatVersion() in
+# https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java
+# The 0xa38eb741 at the end of the message is (Vint) 3000099 the OpenSearch version sending the request.
+
+
 class NettyTraceData:
     class InvalidTraceDataFormat(Exception):
         pass


### PR DESCRIPTION
### Description

OpenSearch nodes return the current node version in the handshake response.

We incorrectly returned the minimum compatibility version of the sending node, which happened to work on 3.0.0 but doesn't work on 2.x.

### Issues Resolved

Fixes #166

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
