### PR TITLE
Stepping @dblock down from maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dblock @dbwiddis
+* @dbwiddis

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,5 +6,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer         | GitHub ID                               | Affiliation |
 | ------------------ | --------------------------------------- | ----------- |
-| Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |
 | Daniel Widdis      | [dbwiddis](https://github.com/dbwiddis) | Amazon      |
+
+## Emeritus
+
+| Maintainer         | GitHub ID                               | Affiliation |
+| ------------------ | --------------------------------------- | ----------- |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Independent |


### PR DESCRIPTION
### Description

Trying to narrow down the repos I pay attention to while I no longer work on OpenSearch full time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
